### PR TITLE
Adding support for merge method when using lgtm

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ jobs:
       - uses: jpmcb/prow-github-actions
         with:
           jobs: 'lgtm'
+          merge-method: merge
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   jobs:
     description: "The jobs to automatically run on event. Space delimited. Expect commands on own line."
     required: false
+  merge-method:
+    description: "How your pull-request will be merged.  Options: merge, squash, rebase"
+    required: false
+    default: merge
 branding:
   color: blue
   icon: anchor

--- a/docs/automatic-merging.md
+++ b/docs/automatic-merging.md
@@ -16,6 +16,7 @@ jobs:
       - uses: jpmcb/prow-github-actions
         with:
           jobs: 'lgtm'
+          merge-method: merge
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 ```
 This Github workflow will check every hour

--- a/src/cronJobs/lgtm.ts
+++ b/src/cronJobs/lgtm.ts
@@ -101,9 +101,11 @@ const getOpenPrs = async (
 const tryMergePr = async (
   pr: Octokit.PullsListResponseItem,
   octokit: github.GitHub,
-  context: Context = github.context,
-  merge_method: Octokit.PullsMergeParams = core.getInput('merge-method') ? core.getInput('merge-method') : 'merge'
+  context: Context = github.context
 ): Promise<void> => {
+
+  const mergeMethod = core.getInput('merge-method') ? core.getInput('merge-method') : 'merge'
+
   // if pr has label 'lgtm', attempt to merge
   // but not if it has the 'hold' label
   if (
@@ -114,7 +116,7 @@ const tryMergePr = async (
       await octokit.pulls.merge({
         ...context.repo,
         pull_number: pr.number,
-        merge_method: merge_method
+        merge_method: mergeMethod
       })
     } catch (e) {
       core.debug(`could not merge pr ${pr.number}: ${e}`)

--- a/src/cronJobs/lgtm.ts
+++ b/src/cronJobs/lgtm.ts
@@ -102,7 +102,7 @@ const tryMergePr = async (
   pr: Octokit.PullsListResponseItem,
   octokit: github.GitHub,
   context: Context = github.context,
-  merge_method: string = core.getInput('merge-method') ? core.getInput('merge-method') : 'merge'
+  merge_method: Octokit.PullsMergeParams = core.getInput('merge-method') ? core.getInput('merge-method') : 'merge'
 ): Promise<void> => {
   // if pr has label 'lgtm', attempt to merge
   // but not if it has the 'hold' label

--- a/src/cronJobs/lgtm.ts
+++ b/src/cronJobs/lgtm.ts
@@ -112,7 +112,8 @@ const tryMergePr = async (
     try {
       await octokit.pulls.merge({
         ...context.repo,
-        pull_number: pr.number
+        pull_number: pr.number,
+        merge_method: core.getInput('merge-method') ? core.getInput('merge-method') : 'merge'
       })
     } catch (e) {
       core.debug(`could not merge pr ${pr.number}: ${e}`)

--- a/src/cronJobs/lgtm.ts
+++ b/src/cronJobs/lgtm.ts
@@ -101,7 +101,8 @@ const getOpenPrs = async (
 const tryMergePr = async (
   pr: Octokit.PullsListResponseItem,
   octokit: github.GitHub,
-  context: Context = github.context
+  context: Context = github.context,
+  merge_method: string = core.getInput('merge-method') ? core.getInput('merge-method') : 'merge'
 ): Promise<void> => {
   // if pr has label 'lgtm', attempt to merge
   // but not if it has the 'hold' label
@@ -113,7 +114,7 @@ const tryMergePr = async (
       await octokit.pulls.merge({
         ...context.repo,
         pull_number: pr.number,
-        merge_method: core.getInput('merge-method') ? core.getInput('merge-method') : 'merge'
+        merge_method: merge_method
       })
     } catch (e) {
       core.debug(`could not merge pr ${pr.number}: ${e}`)


### PR DESCRIPTION
I would like to be able to specify how my pull requests are merged.

This adds support to select the merge method based on: https://octokit.github.io/rest.js/v18#pulls-merge

This will still default to `merge` if the additional input is not used, but allow for selection.