### PR TITLE
Fix main test when run for a PR

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -9,7 +9,21 @@ test('runs with no options', () => {
     env: process.env
   }
 
-  expect(cp.execSync(`node ${ip}`, options).toString()).toContain(
-    'not yet supported'
-  )
+  // When this test is run through GitHub Actions, GITHUB_EVENT_NAME is set to pull_request
+  // clear it out so that we hit the default behavior when nothing is specified
+  if (options.env) {
+    options.env.GITHUB_EVENT_NAME = ''
+  }
+
+  try {
+    expect(cp.execSync(`node ${ip}`, options).toString()).toContain(
+      'not yet supported'
+    )
+  } catch (e) {
+    console.log(
+      "Calling the github action's main function without any context failed:",
+      e.output.toString()
+    )
+    throw e
+  }
 })


### PR DESCRIPTION
The main test relies on the current GitHub event name, and that is populated via the environment variable GITHUB_EVENT_NAME.

When you run locally, that's unset, and the test passes.

When you run the workflow after pushing to main, it's set to "push", which isn't handled by main.ts, so it hits the default case and returns "not yet supported".

But when the workflow is run in a PR, that env var is set to "pull_request" which is an event that main tries to handle. So the test fails in an unexpected way (throwing an error) instead of printing "not yet supported".

I have updated the test to clear out GITHUB_EVENT_NAME so that we get the same test behavior in all cases.

Fixes #54 