### PR TITLE
Comment when /lgtm or /approve are unauthorized

### DIFF
--- a/__tests__/issueCommentTest/approve.test.ts
+++ b/__tests__/issueCommentTest/approve.test.ts
@@ -25,7 +25,7 @@ describe('/approve', () => {
     }
   })
 
-  it('throws if commenter is not an approver in OWNERS', async () => {
+  it('fails if commenter is not an approver in OWNERS', async () => {
     const owners = Buffer.from(
       `
 reviewers:
@@ -50,21 +50,27 @@ reviewers:
 
     // Mock the reply that the user is not authorized
     nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/comments')
+      .post('/repos/Codertocat/Hello-World/issues/1/comments', (req) => {
+        expect(req.body).toContain(wantErr)
+        return true
+      })
       .reply(200)
 
     issueCommentEventAssign.comment.body = '/approve'
     const commentContext = new utils.mockContext(issueCommentEventAssign)
 
-    await expect(() => approve(commentContext)).rejects.toThrowError(wantErr)
+    await handleIssueComment(commentContext)
   })
 
-  it('throws if commenter is not an org member or collaborator', async () => {
+  it('fails if commenter is not an org member or collaborator', async () => {
     const wantErr = `Codertocat is not a org member or collaborator`
 
     // Mock the reply that the user is not authorized
     nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/comments')
+      .post('/repos/Codertocat/Hello-World/issues/1/comments', (req) => {
+        expect(req.body).toContain(wantErr)
+        return true
+      })
       .reply(200)
 
     nock(utils.api)
@@ -74,7 +80,7 @@ reviewers:
     issueCommentEventAssign.comment.body = '/approve'
     const commentContext = new utils.mockContext(issueCommentEventAssign)
 
-    await expect(() => approve(commentContext)).rejects.toThrowError(wantErr)
+    await handleIssueComment(commentContext)
   })
 
   it('approves if commenter is an approver in OWNERS', async () => {

--- a/__tests__/issueCommentTest/approve.test.ts
+++ b/__tests__/issueCommentTest/approve.test.ts
@@ -1,7 +1,6 @@
 import nock from 'nock'
 
 import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
-import {approve} from '../../src/issueComment/approve'
 
 import * as utils from '../testUtils'
 

--- a/__tests__/issueCommentTest/approve.test.ts
+++ b/__tests__/issueCommentTest/approve.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock'
 
 import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
-import { approve } from '../../src/issueComment/approve'
+import {approve} from '../../src/issueComment/approve'
 
 import * as utils from '../testUtils'
 
@@ -15,7 +15,7 @@ describe('/approve', () => {
     nock.cleanAll()
     utils.setupActionsEnv('/approve')
   })
-  afterEach(()=>{
+  afterEach(() => {
     if (!nock.isDone()) {
       throw new Error(
         `Not all nock interceptors were used: ${JSON.stringify(
@@ -24,34 +24,49 @@ describe('/approve', () => {
       )
     }
   })
-  
+
   it('throws if commenter is not an approver in OWNERS', async () => {
-    const owners = Buffer.from(`
+    const owners = Buffer.from(
+      `
 reviewers:
 - Codertocat
-    `).toString('base64')
-  
+    `
+    ).toString('base64')
+
     const contentResponse = {
-      type: "file",
-      encoding: "base64",
+      type: 'file',
+      encoding: 'base64',
       size: 4096,
-      name: "OWNERS",
-      path: "OWNERS",
+      name: 'OWNERS',
+      path: 'OWNERS',
       content: owners
     }
-    
+
     nock(utils.api)
       .get('/repos/Codertocat/Hello-World/contents/OWNERS')
       .reply(200, contentResponse)
 
+    const wantErr = `Codertocat is not included in the approvers role in the OWNERS file`
+
+    // Mock the reply that the user is not authorized
+    nock(utils.api)
+      .post('/repos/Codertocat/Hello-World/issues/1/comments')
+      .reply(200)
+
     issueCommentEventAssign.comment.body = '/approve'
     const commentContext = new utils.mockContext(issueCommentEventAssign)
 
-    expect(() => approve(commentContext))
-      .rejects.toThrowError('Codertocat is not included in the approvers role in the OWNERS file')
+    await expect(() => approve(commentContext)).rejects.toThrowError(wantErr)
   })
 
   it('throws if commenter is not an org member or collaborator', async () => {
+    const wantErr = `Codertocat is not a org member or collaborator`
+
+    // Mock the reply that the user is not authorized
+    nock(utils.api)
+      .post('/repos/Codertocat/Hello-World/issues/1/comments')
+      .reply(200)
+
     nock(utils.api)
       .get('/repos/Codertocat/Hello-World/contents/OWNERS')
       .reply(404)
@@ -59,22 +74,23 @@ reviewers:
     issueCommentEventAssign.comment.body = '/approve'
     const commentContext = new utils.mockContext(issueCommentEventAssign)
 
-    expect(() => approve(commentContext))
-      .rejects.toThrowError('Codertocat is not a org member or collaborator')
+    await expect(() => approve(commentContext)).rejects.toThrowError(wantErr)
   })
 
   it('approves if commenter is an approver in OWNERS', async () => {
-    const owners = Buffer.from(`
+    const owners = Buffer.from(
+      `
 approvers:
 - Codertocat
-    `).toString('base64')
-     
+    `
+    ).toString('base64')
+
     const contentResponse = {
-      type: "file",
-      encoding: "base64",
+      type: 'file',
+      encoding: 'base64',
       size: 4096,
-      name: "OWNERS",
-      path: "OWNERS",
+      name: 'OWNERS',
+      path: 'OWNERS',
       content: owners
     }
     nock(utils.api)
@@ -101,9 +117,7 @@ approvers:
       .get('/repos/Codertocat/Hello-World/contents/OWNERS')
       .reply(404)
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/Codertocat')
-      .reply(204)
+    nock(utils.api).get('/orgs/Codertocat/members/Codertocat').reply(204)
 
     nock(utils.api)
       .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
@@ -125,17 +139,19 @@ approvers:
   })
 
   it('removes approval with the /approve cancel command if approver in OWNERS file', async () => {
-    const owners = Buffer.from(`
+    const owners = Buffer.from(
+      `
 approvers:
 - some-user
-`).toString('base64')
-         
+`
+    ).toString('base64')
+
     const contentResponse = {
-      type: "file",
-      encoding: "base64",
+      type: 'file',
+      encoding: 'base64',
       size: 4096,
-      name: "OWNERS",
-      path: "OWNERS",
+      name: 'OWNERS',
+      path: 'OWNERS',
       content: owners
     }
     nock(utils.api)
@@ -169,10 +185,8 @@ approvers:
     nock(utils.api)
       .get('/repos/Codertocat/Hello-World/contents/OWNERS')
       .reply(404)
-      
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/some-user')
-      .reply(404)
+
+    nock(utils.api).get('/orgs/Codertocat/members/some-user').reply(404)
 
     nock(utils.api)
       .get('/repos/Codertocat/Hello-World/collaborators/some-user')

--- a/__tests__/label/lgtm.test.ts
+++ b/__tests__/label/lgtm.test.ts
@@ -1,7 +1,6 @@
 import nock from 'nock'
 
 import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
-import {lgtm} from '../../src/labels/lgtm'
 
 import * as utils from '../testUtils'
 

--- a/src/utils/comments.ts
+++ b/src/utils/comments.ts
@@ -1,0 +1,27 @@
+import * as github from '@actions/github'
+import {Context} from '@actions/github/lib/context'
+
+/**
+ * createComment comments on the specified issue or pull request
+ *
+ * @param octokit - a hydrated github client
+ * @param context - the github actions event context
+ * @param issueNum - the issue associated with this runtime
+ * @param message - the comment message body
+ */
+export const createComment = async (
+  octokit: github.GitHub,
+  context: Context,
+  issueNum: number,
+  message: string
+): Promise<void> => {
+  try {
+    await octokit.issues.createComment({
+      ...context.repo,
+      issue_number: issueNum,
+      body: message
+    })
+  } catch (e) {
+    throw new Error(`could not add comment: ${e}`)
+  }
+}


### PR DESCRIPTION
When someone tries to use /lgtm or /approve, but they are not authorized to perform that action, log the error but also comment back on the pull request so that they know that their slash command didn't work.

Screenshot below shows what the comments look like when you aren't in the OWNERS file, or if there isn't an OWNERS file, for /lgtm and /approve.

<img width="861" alt="Screen Shot 2022-05-14 at 9 10 59 PM" src="https://user-images.githubusercontent.com/103465932/168454269-11bbccd1-e37c-4a54-8d1d-818863313054.png">
