### PR TITLE
Refactor: Bring everything up to speed with new deps and node 20

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -58,9 +58,8 @@
     },
     "settings": {
     "import/resolver": {
-      "node": {
-        "extensions": [".js", ".jsx", ".ts", ".tsx"]
-      }
+      "typescript": true,
+      "node": true
     }
   }
 }

--- a/__tests__/cronJobTest/labelPr.test.ts
+++ b/__tests__/cronJobTest/labelPr.test.ts
@@ -1,6 +1,7 @@
-import nock from 'nock'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
 
-import {handleCronJobs} from '../../src/cronJobs/handleCronJob'
+import { handleCronJobs } from '../../src/cronJobs/handleCronJob'
 import * as utils from '../testUtils'
 
 import pullReqOpenedEvent from '../fixtures/pullReq/pullReqOpenedEvent.json'
@@ -9,11 +10,30 @@ import labelFileContents from '../fixtures/labels/labelFileContentsResp.json'
 import prListFiles from '../fixtures/pullReq/pullReqListFiles.json'
 import prListTestFiles from '../fixtures/pullReq/pullReqListTestFiles.json'
 
-nock.disableNetConnect()
+const server = setupServer(
+  // /repos/Codertocat/Hello-World/pulls?page={1,2}
+  rest.get(`${utils.api}/repos/Codertocat/Hello-World/pulls`,
+    (req, res, ctx) => {
+      const page = req.url.searchParams.get('page')
+
+      if (page == '1') {
+        return res(ctx.status(200), ctx.json(listPullReqs))
+      } else {
+        return res(ctx.status(200), ctx.json([]))
+      }
+    }
+  ),
+  rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+    utils.mockResponse(200, labelFileContents)),
+)
+beforeAll(() => server.listen({
+  onUnhandledRequest: 'warn',
+}))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 describe('cronLabelPr', () => {
   beforeEach(() => {
-    nock.cleanAll()
     utils.setupActionsEnv('/area')
   })
 
@@ -24,35 +44,18 @@ describe('cronLabelPr', () => {
     // Instead, we use it to gain the repo owner and url
     const context = new utils.mockContext(pullReqOpenedEvent)
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/pulls?page=1')
-      .reply(200, listPullReqs)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/2/labels`,
+        utils.mockResponse(200, null, observeReq)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/pulls/2/files`,
+        utils.mockResponse(200, prListFiles)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/pulls?page=2')
-      .reply(200, [])
-
-    let parsedBody = undefined
-    const scope = nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/2/labels', body => {
-        parsedBody = body
-        return body
-      })
-      .reply(200)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/.github/labels.yaml')
-      .reply(200, labelFileContents)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/pulls/2/files')
-      .reply(200, prListFiles)
-
-    await handleCronJobs(context)
-    expect(parsedBody).toEqual({
+    await expect(handleCronJobs(context)).resolves.not.toThrow()
+    expect(observeReq.body()).toEqual({
       labels: ['source']
     })
-    expect(scope.isDone()).toBe(true)
   })
 
   it('labels the PR with the test label from glob', async () => {
@@ -62,34 +65,18 @@ describe('cronLabelPr', () => {
     // Instead, we use it to gain the repo owner and url
     const context = new utils.mockContext(pullReqOpenedEvent)
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/pulls?page=1')
-      .reply(200, listPullReqs)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/2/labels`,
+        utils.mockResponse(200, null, observeReq)),
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/pulls?page=2')
-      .reply(200, [])
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/pulls/2/files`,
+        utils.mockResponse(200, prListTestFiles)),
+    )
 
-    let parsedBody = undefined
-    const scope = nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/2/labels', body => {
-        parsedBody = body
-        return body
-      })
-      .reply(200)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/.github/labels.yaml')
-      .reply(200, labelFileContents)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/pulls/2/files')
-      .reply(200, prListTestFiles)
-
-    await handleCronJobs(context)
-    expect(parsedBody).toEqual({
+    await expect(handleCronJobs(context)).resolves.not.toThrow()
+    expect(observeReq.body()).toEqual({
       labels: ['tests']
     })
-    expect(scope.isDone()).toBe(true)
   })
 })

--- a/__tests__/cronJobTest/labelPr.test.ts
+++ b/__tests__/cronJobTest/labelPr.test.ts
@@ -1,7 +1,7 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
-import { handleCronJobs } from '../../src/cronJobs/handleCronJob'
+import {handleCronJobs} from '../../src/cronJobs/handleCronJob'
 import * as utils from '../testUtils'
 
 import pullReqOpenedEvent from '../fixtures/pullReq/pullReqOpenedEvent.json'
@@ -12,7 +12,8 @@ import prListTestFiles from '../fixtures/pullReq/pullReqListTestFiles.json'
 
 const server = setupServer(
   // /repos/Codertocat/Hello-World/pulls?page={1,2}
-  rest.get(`${utils.api}/repos/Codertocat/Hello-World/pulls`,
+  rest.get(
+    `${utils.api}/repos/Codertocat/Hello-World/pulls`,
     (req, res, ctx) => {
       const page = req.url.searchParams.get('page')
 
@@ -23,12 +24,16 @@ const server = setupServer(
       }
     }
   ),
-  rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
-    utils.mockResponse(200, labelFileContents)),
+  rest.get(
+    `${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+    utils.mockResponse(200, labelFileContents)
+  )
 )
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -44,12 +49,16 @@ describe('cronLabelPr', () => {
     // Instead, we use it to gain the repo owner and url
     const context = new utils.mockContext(pullReqOpenedEvent)
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/2/labels`,
-        utils.mockResponse(200, null, observeReq)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/pulls/2/files`,
-        utils.mockResponse(200, prListFiles)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/2/labels`,
+        utils.mockResponse(200, null, observeReq)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/2/files`,
+        utils.mockResponse(200, prListFiles)
+      )
     )
 
     await expect(handleCronJobs(context)).resolves.not.toThrow()
@@ -65,13 +74,17 @@ describe('cronLabelPr', () => {
     // Instead, we use it to gain the repo owner and url
     const context = new utils.mockContext(pullReqOpenedEvent)
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/2/labels`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/2/labels`,
+        utils.mockResponse(200, null, observeReq)
+      ),
 
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/pulls/2/files`,
-        utils.mockResponse(200, prListTestFiles)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/2/files`,
+        utils.mockResponse(200, prListTestFiles)
+      )
     )
 
     await expect(handleCronJobs(context)).resolves.not.toThrow()

--- a/__tests__/cronJobTest/lgtm.test.ts
+++ b/__tests__/cronJobTest/lgtm.test.ts
@@ -1,7 +1,7 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
-import { handleCronJobs } from '../../src/cronJobs/handleCronJob'
+import {handleCronJobs} from '../../src/cronJobs/handleCronJob'
 import * as utils from '../testUtils'
 
 import pullReqOpenedEvent from '../fixtures/pullReq/pullReqOpenedEvent.json'
@@ -9,7 +9,8 @@ import listPullReqs from '../fixtures/pullReq/pullReqListPulls.json'
 
 const server = setupServer(
   // /repos/Codertocat/Hello-World/pulls?state=open&page={1,2}
-  rest.get(`${utils.api}/repos/Codertocat/Hello-World/pulls`,
+  rest.get(
+    `${utils.api}/repos/Codertocat/Hello-World/pulls`,
     (req, res, ctx) => {
       const page = req.url.searchParams.get('page')
 
@@ -19,11 +20,13 @@ const server = setupServer(
         return res(ctx.status(200), ctx.json([]))
       }
     }
-  ),
+  )
 )
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -37,10 +40,12 @@ describe('cronLgtm', () => {
 
     listPullReqs[0].labels[0].name = 'lgtm'
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.put(`${utils.api}/repos/Codertocat/Hello-World/pulls/2/merge`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.put(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/2/merge`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     await expect(handleCronJobs(context)).resolves.not.toThrow()
@@ -59,10 +64,12 @@ describe('cronLgtm', () => {
 
     listPullReqs[0].labels[0].name = 'lgtm'
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.put(`${utils.api}/repos/Codertocat/Hello-World/pulls/2/merge`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.put(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/2/merge`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     await expect(handleCronJobs(context)).resolves.not.toThrow()
@@ -81,10 +88,12 @@ describe('cronLgtm', () => {
 
     listPullReqs[0].labels[0].name = 'lgtm'
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.put(`${utils.api}/repos/Codertocat/Hello-World/pulls/2/merge`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.put(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/2/merge`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     await expect(handleCronJobs(context)).resolves.not.toThrow()
@@ -102,13 +111,13 @@ describe('cronLgtm', () => {
 
     listPullReqs[0].labels[0].name = 'lgtm'
     listPullReqs[0].labels.push({
-      "id": 1,
-      "node_id": "123",
-      "url": "https://api.github.com/repos/octocat/Hello-World/labels/hold",
-      "name": "hold",
-      "description": "looks good to me",
-      "color": "f29513",
-      "default": true
+      id: 1,
+      node_id: '123',
+      url: 'https://api.github.com/repos/octocat/Hello-World/labels/hold',
+      name: 'hold',
+      description: 'looks good to me',
+      color: 'f29513',
+      default: true
     })
 
     await expect(handleCronJobs(context)).resolves.not.toThrow()

--- a/__tests__/issueCommentTest/approve.test.ts
+++ b/__tests__/issueCommentTest/approve.test.ts
@@ -1,7 +1,7 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
-import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
 
 import * as utils from '../testUtils'
 
@@ -9,9 +9,11 @@ import pullReqListReviews from '../fixtures/pullReq/pullReqListReviews.json'
 import issueCommentEventAssign from '../fixtures/issues/assign/issueCommentEventAssign.json'
 
 const server = setupServer()
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -38,16 +40,20 @@ reviewers:
     }
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
-        utils.mockResponse(200, contentResponse)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(200, contentResponse)
+      )
     )
     const wantErr = `Codertocat is not included in the approvers role in the OWNERS file`
 
     // Mock the reply that the user is not authorized
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     issueCommentEventAssign.comment.body = '/approve'
@@ -62,19 +68,27 @@ reviewers:
     const wantErr = `Codertocat is not a org member or collaborator`
 
     // Mock the reply that the user is not authorized
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)
+      )
     )
 
     issueCommentEventAssign.comment.body = '/approve'
@@ -102,14 +116,18 @@ reviewers:
       content: owners
     }
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
-        utils.mockResponse(200, contentResponse)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(200, contentResponse)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     issueCommentEventAssign.comment.body = '/approve'
@@ -124,18 +142,26 @@ reviewers:
 
   it('approves if commenter is an org member', async () => {
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     issueCommentEventAssign.comment.body = '/approve'
@@ -165,16 +191,22 @@ reviewers:
       content: owners
     }
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
-        utils.mockResponse(200, contentResponse)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
-        utils.mockResponse(200, pullReqListReviews)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(200, contentResponse)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
+        utils.mockResponse(200, pullReqListReviews)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.put(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews/80/dismissals`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.put(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews/80/dismissals`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     issueCommentEventAssign.comment.body = '/approve cancel'
@@ -190,20 +222,30 @@ reviewers:
 
   it('removes approval with the /approve cancel command if commenter is collaborator', async () => {
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
-        utils.mockResponse(200, pullReqListReviews)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
+        utils.mockResponse(200, pullReqListReviews)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.put(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews/80/dismissals`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.put(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews/80/dismissals`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     issueCommentEventAssign.comment.body = '/approve cancel'

--- a/__tests__/issueCommentTest/approve.test.ts
+++ b/__tests__/issueCommentTest/approve.test.ts
@@ -1,27 +1,23 @@
-import nock from 'nock'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
 
-import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
+import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 
 import * as utils from '../testUtils'
 
 import pullReqListReviews from '../fixtures/pullReq/pullReqListReviews.json'
 import issueCommentEventAssign from '../fixtures/issues/assign/issueCommentEventAssign.json'
 
-nock.disableNetConnect()
+const server = setupServer()
+beforeAll(() => server.listen({
+  onUnhandledRequest: 'warn',
+}))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 describe('/approve', () => {
   beforeEach(() => {
-    nock.cleanAll()
     utils.setupActionsEnv('/approve')
-  })
-  afterEach(() => {
-    if (!nock.isDone()) {
-      throw new Error(
-        `Not all nock interceptors were used: ${JSON.stringify(
-          nock.pendingMocks()
-        )}`
-      )
-    }
   })
 
   it('fails if commenter is not an approver in OWNERS', async () => {
@@ -41,52 +37,122 @@ reviewers:
       content: owners
     }
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/OWNERS')
-      .reply(200, contentResponse)
-
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(200, contentResponse)),
+    )
     const wantErr = `Codertocat is not included in the approvers role in the OWNERS file`
 
     // Mock the reply that the user is not authorized
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/comments', (req) => {
-        expect(req.body).toContain(wantErr)
-        return true
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     issueCommentEventAssign.comment.body = '/approve'
     const commentContext = new utils.mockContext(issueCommentEventAssign)
 
     await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(observeReq.body().body).toContain(wantErr)
   })
 
   it('fails if commenter is not an org member or collaborator', async () => {
     const wantErr = `Codertocat is not a org member or collaborator`
 
     // Mock the reply that the user is not authorized
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/comments', (req) => {
-        expect(req.body).toContain(wantErr)
-        return true
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/OWNERS')
-      .reply(404)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)),
+    )
 
     issueCommentEventAssign.comment.body = '/approve'
     const commentContext = new utils.mockContext(issueCommentEventAssign)
 
     await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(observeReq.body().body).toContain(wantErr)
   })
 
   it('approves if commenter is an approver in OWNERS', async () => {
     const owners = Buffer.from(
       `
-approvers:
-- Codertocat
+    approvers:
+    - Codertocat
+        `
+    ).toString('base64')
+
+    const contentResponse = {
+      type: 'file',
+      encoding: 'base64',
+      size: 4096,
+      name: 'OWNERS',
+      path: 'OWNERS',
+      content: owners
+    }
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(200, contentResponse)),
+    )
+
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
+        utils.mockResponse(200, null, observeReq)),
+    )
+
+    issueCommentEventAssign.comment.body = '/approve'
+    const commentContext = new utils.mockContext(issueCommentEventAssign)
+
+    await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      event: 'APPROVE'
+    })
+  })
+
+  it('approves if commenter is an org member', async () => {
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)),
+    )
+
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
+        utils.mockResponse(200, null, observeReq)),
+    )
+
+    issueCommentEventAssign.comment.body = '/approve'
+    const commentContext = new utils.mockContext(issueCommentEventAssign)
+
+    await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      event: 'APPROVE'
+    })
+  })
+
+  it('removes approval with the /approve cancel command if approver in OWNERS file', async () => {
+    const owners = Buffer.from(
+      `
+    approvers:
+    - some-user
     `
     ).toString('base64')
 
@@ -98,125 +164,56 @@ approvers:
       path: 'OWNERS',
       content: owners
     }
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/OWNERS')
-      .reply(200, contentResponse)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(200, contentResponse)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
+        utils.mockResponse(200, pullReqListReviews)),
+    )
 
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/pulls/1/reviews', body => {
-        expect(body).toMatchObject({
-          event: 'APPROVE'
-        })
-        return true
-      })
-      .reply(200)
-
-    issueCommentEventAssign.comment.body = '/approve'
-    const commentContext = new utils.mockContext(issueCommentEventAssign)
-
-    await handleIssueComment(commentContext)
-  })
-
-  it('approves if commenter is an org member', async () => {
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/OWNERS')
-      .reply(404)
-
-    nock(utils.api).get('/orgs/Codertocat/members/Codertocat').reply(204)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(404)
-
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/pulls/1/reviews', body => {
-        expect(body).toMatchObject({
-          event: 'APPROVE'
-        })
-        return true
-      })
-      .reply(200)
-
-    issueCommentEventAssign.comment.body = '/approve'
-    const commentContext = new utils.mockContext(issueCommentEventAssign)
-
-    await handleIssueComment(commentContext)
-  })
-
-  it('removes approval with the /approve cancel command if approver in OWNERS file', async () => {
-    const owners = Buffer.from(
-      `
-approvers:
-- some-user
-`
-    ).toString('base64')
-
-    const contentResponse = {
-      type: 'file',
-      encoding: 'base64',
-      size: 4096,
-      name: 'OWNERS',
-      path: 'OWNERS',
-      content: owners
-    }
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/OWNERS')
-      .reply(200, contentResponse)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/pulls/1/reviews')
-      .reply(200, pullReqListReviews)
-
-    nock(utils.api)
-      .put(
-        '/repos/Codertocat/Hello-World/pulls/1/reviews/80/dismissals',
-        body => {
-          expect(body).toMatchObject({
-            message: `Canceled through prow-github-actions by @some-user`
-          })
-          return true
-        }
-      )
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.put(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews/80/dismissals`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     issueCommentEventAssign.comment.body = '/approve cancel'
     issueCommentEventAssign.comment.user.login = 'some-user'
     const commentContext = new utils.mockContext(issueCommentEventAssign)
 
     await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      message: `Canceled through prow-github-actions by @some-user`
+    })
   })
 
   it('removes approval with the /approve cancel command if commenter is collaborator', async () => {
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/OWNERS')
-      .reply(404)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
+        utils.mockResponse(200, pullReqListReviews)),
+    )
 
-    nock(utils.api).get('/orgs/Codertocat/members/some-user').reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/some-user')
-      .reply(204)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/pulls/1/reviews')
-      .reply(200, pullReqListReviews)
-
-    nock(utils.api)
-      .put(
-        '/repos/Codertocat/Hello-World/pulls/1/reviews/80/dismissals',
-        body => {
-          expect(body).toMatchObject({
-            message: `Canceled through prow-github-actions by @some-user`
-          })
-          return true
-        }
-      )
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.put(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews/80/dismissals`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     issueCommentEventAssign.comment.body = '/approve cancel'
     issueCommentEventAssign.comment.user.login = 'some-user'
     const commentContext = new utils.mockContext(issueCommentEventAssign)
 
     await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      message: `Canceled through prow-github-actions by @some-user`
+    })
   })
 })

--- a/__tests__/issueCommentTest/assign.test.ts
+++ b/__tests__/issueCommentTest/assign.test.ts
@@ -1,7 +1,7 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
-import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
 import * as utils from '../testUtils'
 
 import issueAssignedResp from '../fixtures/issues/assign/issueAssignedResponse.json'
@@ -9,9 +9,11 @@ import issueCommentEventAssign from '../fixtures/issues/assign/issueCommentEvent
 import issueListComments from '../fixtures/issues/assign/issueListComments.json'
 
 const server = setupServer()
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -22,18 +24,26 @@ describe('/assign', () => {
 
   it('handles self assigning with comment /assign', async () => {
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
-        utils.mockResponse(201, issueAssignedResp, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueAssignedResp, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEventAssign)
@@ -49,18 +59,26 @@ describe('/assign', () => {
     issueCommentEventAssign.comment.body = '/assign @some-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
-        utils.mockResponse(201, issueAssignedResp, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueAssignedResp, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEventAssign)
@@ -76,18 +94,26 @@ describe('/assign', () => {
     issueCommentEventAssign.comment.body = '/assign some-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
-        utils.mockResponse(201, issueAssignedResp, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueAssignedResp, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEventAssign)
@@ -103,22 +129,34 @@ describe('/assign', () => {
     issueCommentEventAssign.comment.body = '/assign @some-user @other-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/orgs/Codertocat/members/other-user`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/other-user`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/other-user`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/other-user`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
-        utils.mockResponse(201, issueAssignedResp, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueAssignedResp, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEventAssign)
@@ -134,18 +172,26 @@ describe('/assign', () => {
     issueCommentEventAssign.comment.body = '/assign @some-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
-        utils.mockResponse(201, issueAssignedResp, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueAssignedResp, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEventAssign)
@@ -161,18 +207,26 @@ describe('/assign', () => {
     issueCommentEventAssign.comment.body = '/assign @some-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
-        utils.mockResponse(201, issueAssignedResp, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueAssignedResp, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEventAssign)
@@ -188,18 +242,26 @@ describe('/assign', () => {
     issueCommentEventAssign.comment.body = '/assign @some-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(200, issueListComments)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, issueListComments)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
-        utils.mockResponse(201, issueAssignedResp, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueAssignedResp, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEventAssign)

--- a/__tests__/issueCommentTest/assign.test.ts
+++ b/__tests__/issueCommentTest/assign.test.ts
@@ -1,236 +1,213 @@
-import nock from 'nock'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
 
-import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
+import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 import * as utils from '../testUtils'
 
 import issueAssignedResp from '../fixtures/issues/assign/issueAssignedResponse.json'
 import issueCommentEventAssign from '../fixtures/issues/assign/issueCommentEventAssign.json'
 import issueListComments from '../fixtures/issues/assign/issueListComments.json'
 
-nock.disableNetConnect()
+const server = setupServer()
+beforeAll(() => server.listen({
+  onUnhandledRequest: 'warn',
+}))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 describe('/assign', () => {
   beforeEach(() => {
-    nock.cleanAll()
     utils.setupActionsEnv('/assign')
   })
 
   it('handles self assigning with comment /assign', async () => {
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/assignees', body => {
-        expect(body).toMatchObject({
-          assignees: ['Codertocat']
-        })
-        return true
-      })
-      .reply(201, issueAssignedResp)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueAssignedResp, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEventAssign)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      assignees: ['Codertocat']
+    })
   })
 
   it('handles assigning another user with /assign @username', async () => {
     issueCommentEventAssign.comment.body = '/assign @some-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/some-user')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/some-user')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/assignees', body => {
-        expect(body).toMatchObject({
-          assignees: ['some-user']
-        })
-        return true
-      })
-      .reply(201, issueAssignedResp)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueAssignedResp, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEventAssign)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      assignees: ['some-user']
+    })
   })
 
   it('handles assigning another user with /assign username', async () => {
     issueCommentEventAssign.comment.body = '/assign some-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/some-user')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/some-user')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/assignees', body => {
-        expect(body).toMatchObject({
-          assignees: ['some-user']
-        })
-        return true
-      })
-      .reply(201, issueAssignedResp)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueAssignedResp, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEventAssign)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      assignees: ['some-user']
+    })
   })
 
   it('handles assigning multiple users', async () => {
     issueCommentEventAssign.comment.body = '/assign @some-user @other-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/some-user')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/orgs/Codertocat/members/other-user`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/other-user`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/other-user')
-      .reply(204)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/some-user')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/assignees', body => {
-        expect(body).toMatchObject({
-          assignees: ['some-user', 'other-user']
-        })
-        return true
-      })
-      .reply(201, issueAssignedResp)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueAssignedResp, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEventAssign)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      assignees: ['some-user', 'other-user']
+    })
   })
 
   it('assigns user if they are an org member', async () => {
     issueCommentEventAssign.comment.body = '/assign @some-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/some-user')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/some-user')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/assignees', body => {
-        expect(body).toMatchObject({
-          assignees: ['some-user']
-        })
-        return true
-      })
-      .reply(201, issueAssignedResp)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueAssignedResp, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEventAssign)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      assignees: ['some-user']
+    })
   })
 
   it('assigns user if they are a repo collaborator', async () => {
     issueCommentEventAssign.comment.body = '/assign @some-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/some-user')
-      .reply(404)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/some-user')
-      .reply(204)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/assignees', body => {
-        expect(body).toMatchObject({
-          assignees: ['some-user']
-        })
-        return true
-      })
-      .reply(201, issueAssignedResp)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueAssignedResp, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEventAssign)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      assignees: ['some-user']
+    })
   })
 
   it('assigns user if they have previously commented', async () => {
     issueCommentEventAssign.comment.body = '/assign @some-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/some-user')
-      .reply(404)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, issueListComments)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/some-user')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(200, issueListComments)
-
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/assignees', body => {
-        expect(body).toMatchObject({
-          assignees: ['some-user']
-        })
-        return true
-      })
-      .reply(201, issueAssignedResp)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueAssignedResp, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEventAssign)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      assignees: ['some-user']
+    })
   })
 })

--- a/__tests__/issueCommentTest/cc.test.ts
+++ b/__tests__/issueCommentTest/cc.test.ts
@@ -1,7 +1,7 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
-import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
 import * as utils from '../testUtils'
 
 import pullReviewRequested from '../fixtures/pullReq/pullReviewRequested.json'
@@ -9,9 +9,11 @@ import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import issueListComments from '../fixtures/issues/assign/issueListComments.json'
 
 const server = setupServer()
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -24,14 +26,18 @@ describe('/cc', () => {
     issueCommentEvent.comment.body = '/cc'
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(204)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
-        utils.mockResponse(201, pullReviewRequested, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(201, pullReviewRequested, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -46,18 +52,26 @@ describe('/cc', () => {
   it('handles cc-ing another user with /cc @username', async () => {
     issueCommentEvent.comment.body = '/cc @some-user'
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
-        utils.mockResponse(201, pullReviewRequested, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(201, pullReviewRequested, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -73,18 +87,26 @@ describe('/cc', () => {
     issueCommentEvent.comment.body = '/cc some-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
-        utils.mockResponse(201, pullReviewRequested, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(201, pullReviewRequested, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -100,22 +122,34 @@ describe('/cc', () => {
     issueCommentEvent.comment.body = '/cc @some-user @other-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/orgs/Codertocat/members/other-user`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/other-user`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/other-user`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/other-user`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
-        utils.mockResponse(201, pullReviewRequested, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(201, pullReviewRequested, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -130,18 +164,26 @@ describe('/cc', () => {
     issueCommentEvent.comment.body = '/cc @some-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
-        utils.mockResponse(201, pullReviewRequested, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(201, pullReviewRequested, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -157,18 +199,26 @@ describe('/cc', () => {
     issueCommentEvent.comment.body = '/cc @some-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
-        utils.mockResponse(201, pullReviewRequested, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(201, pullReviewRequested, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -184,18 +234,26 @@ describe('/cc', () => {
     issueCommentEvent.comment.body = '/cc @some-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(200, issueListComments)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, issueListComments)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
-        utils.mockResponse(201, pullReviewRequested, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(201, pullReviewRequested, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)

--- a/__tests__/issueCommentTest/cc.test.ts
+++ b/__tests__/issueCommentTest/cc.test.ts
@@ -1,230 +1,209 @@
-import nock from 'nock'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
 
-import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
+import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 import * as utils from '../testUtils'
 
 import pullReviewRequested from '../fixtures/pullReq/pullReviewRequested.json'
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import issueListComments from '../fixtures/issues/assign/issueListComments.json'
 
-nock.disableNetConnect()
+const server = setupServer()
+beforeAll(() => server.listen({
+  onUnhandledRequest: 'warn',
+}))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 describe('/cc', () => {
   beforeEach(() => {
-    nock.cleanAll()
     utils.setupActionsEnv('/cc')
   })
 
   it('handles self cc-ing with comment /cc', async () => {
     issueCommentEvent.comment.body = '/cc'
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)),
+    )
 
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/pulls/1/requested_reviewers', body => {
-        expect(body).toMatchObject({
-          reviewers: ['Codertocat']
-        })
-        return true
-      })
-      .reply(201, pullReviewRequested)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(201, pullReviewRequested, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      reviewers: ['Codertocat']
+    })
   })
 
   it('handles cc-ing another user with /cc @username', async () => {
     issueCommentEvent.comment.body = '/cc @some-user'
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/some-user')
-      .reply(204)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/some-user')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/pulls/1/requested_reviewers', body => {
-        expect(body).toMatchObject({
-          reviewers: ['some-user']
-        })
-        return true
-      })
-      .reply(201, pullReviewRequested)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(201, pullReviewRequested, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      reviewers: ['some-user']
+    })
   })
 
   it('handles cc-ing another user with /cc username', async () => {
     issueCommentEvent.comment.body = '/cc some-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/some-user')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/some-user')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/pulls/1/requested_reviewers', body => {
-        expect(body).toMatchObject({
-          reviewers: ['some-user']
-        })
-        return true
-      })
-      .reply(201, pullReviewRequested)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(201, pullReviewRequested, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      reviewers: ['some-user']
+    })
   })
 
   it('handles cc-ing multiple users', async () => {
     issueCommentEvent.comment.body = '/cc @some-user @other-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/some-user')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/orgs/Codertocat/members/other-user`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/other-user`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/other-user')
-      .reply(204)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/some-user')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/pulls/1/requested_reviewers', body => {
-        expect(body).toMatchObject({
-          reviewers: ['some-user', 'other-user']
-        })
-        return true
-      })
-      .reply(201, pullReviewRequested)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(201, pullReviewRequested, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    expect(observeReq.body()).toMatchObject({
+      reviewers: ['some-user', 'other-user']
+    })
   })
 
   it('ccs user if they are an org member', async () => {
     issueCommentEvent.comment.body = '/cc @some-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/some-user')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/some-user')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/pulls/1/requested_reviewers', body => {
-        expect(body).toMatchObject({
-          reviewers: ['some-user']
-        })
-        return true
-      })
-      .reply(201, pullReviewRequested)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(201, pullReviewRequested, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      reviewers: ['some-user']
+    })
   })
 
   it('assigns user if they are a repo collaborator', async () => {
     issueCommentEvent.comment.body = '/cc @some-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/some-user')
-      .reply(404)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/some-user')
-      .reply(204)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/pulls/1/requested_reviewers', body => {
-        expect(body).toMatchObject({
-          reviewers: ['some-user']
-        })
-        return true
-      })
-      .reply(201, pullReviewRequested)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(201, pullReviewRequested, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      reviewers: ['some-user']
+    })
   })
 
   it('assigns user if they have previously commented', async () => {
     issueCommentEvent.comment.body = '/cc @some-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/some-user')
-      .reply(404)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, issueListComments)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/some-user')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(200, issueListComments)
-
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/pulls/1/requested_reviewers', body => {
-        expect(body).toMatchObject({
-          reviewers: ['some-user']
-        })
-        return true
-      })
-      .reply(201, pullReviewRequested)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(201, pullReviewRequested, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      reviewers: ['some-user']
+    })
   })
 })

--- a/__tests__/issueCommentTest/close.test.ts
+++ b/__tests__/issueCommentTest/close.test.ts
@@ -1,16 +1,18 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
 import * as utils from '../testUtils'
 
-import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 
 const server = setupServer()
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -23,14 +25,18 @@ describe('/close', () => {
     issueCommentEvent.comment.body = '/close much better title'
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(204)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.patch(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.patch(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -38,7 +44,7 @@ describe('/close', () => {
     await handleIssueComment(commentContext)
     await observeReq.called()
     expect(observeReq.body()).toMatchObject({
-      state: "closed"
+      state: 'closed'
     })
   })
 

--- a/__tests__/issueCommentTest/close.test.ts
+++ b/__tests__/issueCommentTest/close.test.ts
@@ -1,10 +1,18 @@
-import nock from 'nock'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
 
 import * as utils from '../testUtils'
 
-import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
+import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
+
+const server = setupServer()
+beforeAll(() => server.listen({
+  onUnhandledRequest: 'warn',
+}))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 describe('/close', () => {
   beforeEach(() => {
@@ -14,24 +22,24 @@ describe('/close', () => {
   it('closes the issue with /close', async () => {
     issueCommentEvent.comment.body = '/close much better title'
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)),
+    )
 
-    nock(utils.api)
-      .patch('/repos/Codertocat/Hello-World/issues/1', body => {
-        expect(body).toMatchObject({
-          state: "closed"
-        })
-        return true
-      })
-      .reply(200)
-    
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.patch(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq)),
+    )
+
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      state: "closed"
+    })
   })
 
   describe('error', () => {

--- a/__tests__/issueCommentTest/lock.test.ts
+++ b/__tests__/issueCommentTest/lock.test.ts
@@ -1,10 +1,18 @@
-import nock from 'nock'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
 
 import * as utils from '../testUtils'
 
-import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
+import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
+
+const server = setupServer()
+beforeAll(() => server.listen({
+  onUnhandledRequest: 'warn',
+}))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 describe('/lock', () => {
   beforeEach(() => {
@@ -14,87 +22,90 @@ describe('/lock', () => {
   it('locks the associated issue', async () => {
     issueCommentEvent.comment.body = '/lock'
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)),
+    )
 
-    nock(utils.api)
-      .put('/repos/Codertocat/Hello-World/issues/1/lock')
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.put(`${utils.api}/repos/Codertocat/Hello-World/issues/1/lock`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
+    await expect(observeReq.called()).resolves.toBe('called')
   })
 
   it('locks the associated issue with given reason off-topic', async () => {
     issueCommentEvent.comment.body = '/lock off-topic'
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)),
+    )
 
-    nock(utils.api)
-      .put('/repos/Codertocat/Hello-World/issues/1/lock', body => {
-        expect(body).toMatchObject({
-          lock_reason: 'off-topic'
-        })
-        return true
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.put(`${utils.api}/repos/Codertocat/Hello-World/issues/1/lock`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      lock_reason: 'off-topic'
+    })
   })
 
   it('locks the associated issue with given reason too-heated', async () => {
     issueCommentEvent.comment.body = '/lock too-heated'
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)),
+    )
 
-    nock(utils.api)
-      .put('/repos/Codertocat/Hello-World/issues/1/lock', body => {
-        expect(body).toMatchObject({
-          lock_reason: 'too heated'
-        })
-        return true
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.put(`${utils.api}/repos/Codertocat/Hello-World/issues/1/lock`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      lock_reason: 'too heated'
+    })
   })
 
   it('locks the associated issue with given reason spam', async () => {
     issueCommentEvent.comment.body = '/lock spam'
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)),
+    )
 
-    nock(utils.api)
-      .put('/repos/Codertocat/Hello-World/issues/1/lock', body => {
-        expect(body).toMatchObject({
-          lock_reason: 'spam'
-        })
-        return true
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.put(`${utils.api}/repos/Codertocat/Hello-World/issues/1/lock`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      lock_reason: 'spam'
+    })
   })
 
   describe('error', () => {

--- a/__tests__/issueCommentTest/lock.test.ts
+++ b/__tests__/issueCommentTest/lock.test.ts
@@ -1,16 +1,18 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
 import * as utils from '../testUtils'
 
-import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 
 const server = setupServer()
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -23,14 +25,18 @@ describe('/lock', () => {
     issueCommentEvent.comment.body = '/lock'
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(204)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.put(`${utils.api}/repos/Codertocat/Hello-World/issues/1/lock`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.put(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/lock`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -43,14 +49,18 @@ describe('/lock', () => {
     issueCommentEvent.comment.body = '/lock off-topic'
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(204)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.put(`${utils.api}/repos/Codertocat/Hello-World/issues/1/lock`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.put(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/lock`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -66,14 +76,18 @@ describe('/lock', () => {
     issueCommentEvent.comment.body = '/lock too-heated'
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(204)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.put(`${utils.api}/repos/Codertocat/Hello-World/issues/1/lock`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.put(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/lock`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -89,14 +103,18 @@ describe('/lock', () => {
     issueCommentEvent.comment.body = '/lock spam'
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(204)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.put(`${utils.api}/repos/Codertocat/Hello-World/issues/1/lock`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.put(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/lock`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)

--- a/__tests__/issueCommentTest/milestone.test.ts
+++ b/__tests__/issueCommentTest/milestone.test.ts
@@ -1,18 +1,20 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
 import * as utils from '../testUtils'
 import * as core from '@actions/core'
 
-import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import repoMilestones from '../fixtures/milestones/repoListMilestones.json'
 
 const server = setupServer()
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -25,19 +27,25 @@ describe('/milestone', () => {
     issueCommentEvent.comment.body = '/milestone some milestone'
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/milestones`,
-        utils.mockResponse(200, repoMilestones)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/milestones`,
+        utils.mockResponse(200, repoMilestones)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.patch(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.patch(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(204)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -53,13 +61,17 @@ describe('/milestone', () => {
     issueCommentEvent.comment.body = '/milestone some milestone'
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/milestones`,
-        utils.mockResponse(200, repoMilestones)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/milestones`,
+        utils.mockResponse(200, repoMilestones)
+      )
     )
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)

--- a/__tests__/issueCommentTest/milestone.test.ts
+++ b/__tests__/issueCommentTest/milestone.test.ts
@@ -1,12 +1,20 @@
-import nock from 'nock'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
 
 import * as utils from '../testUtils'
 import * as core from '@actions/core'
 
-import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
+import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import repoMilestones from '../fixtures/milestones/repoListMilestones.json'
+
+const server = setupServer()
+beforeAll(() => server.listen({
+  onUnhandledRequest: 'warn',
+}))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 describe('/milestone', () => {
   beforeEach(() => {
@@ -16,48 +24,43 @@ describe('/milestone', () => {
   it('adds issue to milestone that already exists', async () => {
     issueCommentEvent.comment.body = '/milestone some milestone'
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/milestones')
-      .reply(200, repoMilestones)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/milestones`,
+        utils.mockResponse(200, repoMilestones)),
+    )
 
-      nock(utils.api)
-      .patch('/repos/Codertocat/Hello-World/issues/1', body => {
-        expect(body).toMatchObject({
-          milestone: 1
-        })
-        return true
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.patch(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      milestone: 1
+    })
   })
 
   it('fails when commenter is not a collaborator', async () => {
     issueCommentEvent.comment.body = '/milestone some milestone'
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/milestones')
-      .reply(200, repoMilestones)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/milestones`,
+        utils.mockResponse(200, repoMilestones)),
+    )
 
-      nock(utils.api)
-      .patch('/repos/Codertocat/Hello-World/issues/1', body => {
-        expect(body).toMatchObject({
-          milestone: 1
-        })
-        return true
-      })
-      .reply(200)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(404)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 

--- a/__tests__/issueCommentTest/reopen.test.ts
+++ b/__tests__/issueCommentTest/reopen.test.ts
@@ -1,16 +1,18 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
 import * as utils from '../testUtils'
 
-import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 
 const server = setupServer()
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -23,14 +25,18 @@ describe('/reopen', () => {
     issueCommentEvent.comment.body = '/reopen much better title'
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(204)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.patch(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.patch(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -38,7 +44,7 @@ describe('/reopen', () => {
     await handleIssueComment(commentContext)
     await observeReq.called()
     expect(observeReq.body()).toMatchObject({
-      state: "open"
+      state: 'open'
     })
   })
 

--- a/__tests__/issueCommentTest/reopen.test.ts
+++ b/__tests__/issueCommentTest/reopen.test.ts
@@ -1,10 +1,18 @@
-import nock from 'nock'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
 
 import * as utils from '../testUtils'
 
-import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
+import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
+
+const server = setupServer()
+beforeAll(() => server.listen({
+  onUnhandledRequest: 'warn',
+}))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 describe('/reopen', () => {
   beforeEach(() => {
@@ -14,24 +22,24 @@ describe('/reopen', () => {
   it('reopens the issue with /reopen', async () => {
     issueCommentEvent.comment.body = '/reopen much better title'
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)),
+    )
 
-    nock(utils.api)
-      .patch('/repos/Codertocat/Hello-World/issues/1', body => {
-        expect(body).toMatchObject({
-          state: "open"
-        })
-        return true
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.patch(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      state: "open"
+    })
   })
 
   describe('error', () => {

--- a/__tests__/issueCommentTest/retitle.test.ts
+++ b/__tests__/issueCommentTest/retitle.test.ts
@@ -1,10 +1,18 @@
-import nock from 'nock'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
 
 import * as utils from '../testUtils'
 
-import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
+import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
+
+const server = setupServer()
+beforeAll(() => server.listen({
+  onUnhandledRequest: 'warn',
+}))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 describe('/retitle', () => {
   beforeEach(() => {
@@ -14,24 +22,24 @@ describe('/retitle', () => {
   it('handles renaming title when user is collaborator', async () => {
     issueCommentEvent.comment.body = '/retitle much better title'
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)),
+    )
 
-    nock(utils.api)
-      .patch('/repos/Codertocat/Hello-World/issues/1', body => {
-        expect(body).toMatchObject({
-          title: "much better title"
-        })
-        return true
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.patch(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      title: "much better title"
+    })
   })
 
   describe('error', () => {

--- a/__tests__/issueCommentTest/retitle.test.ts
+++ b/__tests__/issueCommentTest/retitle.test.ts
@@ -1,16 +1,18 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
 import * as utils from '../testUtils'
 
-import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 
 const server = setupServer()
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -23,14 +25,18 @@ describe('/retitle', () => {
     issueCommentEvent.comment.body = '/retitle much better title'
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(204)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.patch(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.patch(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -38,7 +44,7 @@ describe('/retitle', () => {
     await handleIssueComment(commentContext)
     await observeReq.called()
     expect(observeReq.body()).toMatchObject({
-      title: "much better title"
+      title: 'much better title'
     })
   })
 

--- a/__tests__/issueCommentTest/unassign.test.ts
+++ b/__tests__/issueCommentTest/unassign.test.ts
@@ -1,11 +1,19 @@
-import nock from 'nock'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
 
 import * as utils from '../testUtils'
 
-import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
+import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 
 import issueUnassignedResp from '../fixtures/issues/unassign/issueUnassignedResponse.json'
 import issueCommentEventUnassign from '../fixtures/issues/unassign/issueCommentEventUnassign.json'
+
+const server = setupServer()
+beforeAll(() => server.listen({
+  onUnhandledRequest: 'warn',
+}))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 describe('/unassign', () => {
   beforeEach(() => {
@@ -13,140 +21,127 @@ describe('/unassign', () => {
   })
 
   it('handles self unassignment with comment /unassign', async () => {
-    nock(utils.api)
-      .delete('/repos/Codertocat/Hello-World/issues/1/assignees', body => {
-        expect(body).toMatchObject({
-          assignees: ['Codertocat']
-        })
-        return true
-      })
-      .reply(201, issueUnassignedResp)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueUnassignedResp, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEventUnassign)
 
     await handleIssueComment(commentContext)
-    expect.assertions(1)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      assignees: ['Codertocat']
+    })
   })
 
   it('handles unassign another user with /unassign @username', async () => {
     issueCommentEventUnassign.comment.body = '/unassign @some-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .delete('/repos/Codertocat/Hello-World/issues/1/assignees', body => {
-        expect(body).toMatchObject({
-          assignees: ['some-user']
-        })
-        return true
-      })
-      .reply(201, issueUnassignedResp)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueUnassignedResp, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEventUnassign)
 
     await handleIssueComment(commentContext)
-    expect.assertions(1)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      assignees: ['some-user']
+    })
   })
 
   it('handles unassigning another user with /unassign username', async () => {
     issueCommentEventUnassign.comment.body = '/unassign some-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .delete('/repos/Codertocat/Hello-World/issues/1/assignees', body => {
-        expect(body).toMatchObject({
-          assignees: ['some-user']
-        })
-        return true
-      })
-      .reply(201, issueUnassignedResp)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueUnassignedResp, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEventUnassign)
 
     await handleIssueComment(commentContext)
-    expect.assertions(1)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      assignees: ['some-user']
+    })
   })
 
   it('handles unassigning multiple users', async () => {
     issueCommentEventUnassign.comment.body = '/unassign @some-user @other-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .delete('/repos/Codertocat/Hello-World/issues/1/assignees', body => {
-        expect(body).toMatchObject({
-          assignees: ['some-user', 'other-user']
-        })
-        return true
-      })
-      .reply(201, issueUnassignedResp)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueUnassignedResp, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEventUnassign)
 
     await handleIssueComment(commentContext)
-    expect.assertions(1)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      assignees: ['some-user', 'other-user']
+    })
   })
 
   it('handles unassign another user if commenter is org member', async () => {
     issueCommentEventUnassign.comment.body = '/unassign @some-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .delete('/repos/Codertocat/Hello-World/issues/1/assignees', body => {
-        expect(body).toMatchObject({
-          assignees: ['some-user']
-        })
-        return true
-      })
-      .reply(201, issueUnassignedResp)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueUnassignedResp, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEventUnassign)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      assignees: ['some-user']
+    })
   })
 
   describe('error', () => {

--- a/__tests__/issueCommentTest/unassign.test.ts
+++ b/__tests__/issueCommentTest/unassign.test.ts
@@ -1,17 +1,19 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
 import * as utils from '../testUtils'
 
-import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
 
 import issueUnassignedResp from '../fixtures/issues/unassign/issueUnassignedResponse.json'
 import issueCommentEventUnassign from '../fixtures/issues/unassign/issueCommentEventUnassign.json'
 
 const server = setupServer()
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -21,10 +23,12 @@ describe('/unassign', () => {
   })
 
   it('handles self unassignment with comment /unassign', async () => {
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
-        utils.mockResponse(201, issueUnassignedResp, observeReq)),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueUnassignedResp, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEventUnassign)
@@ -40,18 +44,26 @@ describe('/unassign', () => {
     issueCommentEventUnassign.comment.body = '/unassign @some-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
-        utils.mockResponse(201, issueUnassignedResp, observeReq)),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueUnassignedResp, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEventUnassign)
@@ -67,18 +79,26 @@ describe('/unassign', () => {
     issueCommentEventUnassign.comment.body = '/unassign some-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
-        utils.mockResponse(201, issueUnassignedResp, observeReq)),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueUnassignedResp, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEventUnassign)
@@ -94,18 +114,26 @@ describe('/unassign', () => {
     issueCommentEventUnassign.comment.body = '/unassign @some-user @other-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
-        utils.mockResponse(201, issueUnassignedResp, observeReq)),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueUnassignedResp, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEventUnassign)
@@ -121,18 +149,26 @@ describe('/unassign', () => {
     issueCommentEventUnassign.comment.body = '/unassign @some-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
-        utils.mockResponse(201, issueUnassignedResp, observeReq)),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueUnassignedResp, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEventUnassign)

--- a/__tests__/issueCommentTest/uncc.test.ts
+++ b/__tests__/issueCommentTest/uncc.test.ts
@@ -1,7 +1,7 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
-import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
 import * as utils from '../testUtils'
 
 import pullReviewRequested from '../fixtures/pullReq/pullReviewRequested.json'
@@ -9,9 +9,11 @@ import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import issueListComments from '../fixtures/issues/assign/issueListComments.json'
 
 const server = setupServer()
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -24,16 +26,22 @@ describe('/uncc', () => {
     issueCommentEvent.comment.body = '/uncc'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(204)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -49,18 +57,26 @@ describe('/uncc', () => {
     issueCommentEvent.comment.body = '/uncc @some-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -76,18 +92,26 @@ describe('/uncc', () => {
     issueCommentEvent.comment.body = '/uncc some-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -103,18 +127,26 @@ describe('/uncc', () => {
     issueCommentEvent.comment.body = '/uncc @some-user @other-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -130,18 +162,26 @@ describe('/uncc', () => {
     issueCommentEvent.comment.body = '/uncc @some-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -157,18 +197,26 @@ describe('/uncc', () => {
     issueCommentEvent.comment.body = '/uncc @some-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
@@ -184,18 +232,26 @@ describe('/uncc', () => {
     issueCommentEvent.comment.body = '/uncc @some-user'
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(200, issueListComments)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, issueListComments)
+      )
     )
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     const commentContext = new utils.mockContext(issueCommentEvent)

--- a/__tests__/issueCommentTest/uncc.test.ts
+++ b/__tests__/issueCommentTest/uncc.test.ts
@@ -1,226 +1,209 @@
-import nock from 'nock'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
 
-import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
+import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 import * as utils from '../testUtils'
 
 import pullReviewRequested from '../fixtures/pullReq/pullReviewRequested.json'
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import issueListComments from '../fixtures/issues/assign/issueListComments.json'
 
-nock.disableNetConnect()
+const server = setupServer()
+beforeAll(() => server.listen({
+  onUnhandledRequest: 'warn',
+}))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 describe('/uncc', () => {
   beforeEach(() => {
-    nock.cleanAll()
     utils.setupActionsEnv('/uncc')
   })
 
   it('handles self uncc-ing with comment /uncc', async () => {
     issueCommentEvent.comment.body = '/uncc'
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)),
+    )
 
-    nock(utils.api)
-      .delete('/repos/Codertocat/Hello-World/pulls/1/requested_reviewers', body => {
-        expect(body).toMatchObject({
-          reviewers: ['Codertocat']
-        })
-        return true
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      reviewers: ['Codertocat']
+    })
   })
 
   it('handles uncc-ing another user with /uncc @username', async () => {
     issueCommentEvent.comment.body = '/uncc @some-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .delete('/repos/Codertocat/Hello-World/pulls/1/requested_reviewers', body => {
-        expect(body).toMatchObject({
-          reviewers: ['some-user']
-        })
-        return true
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      reviewers: ['some-user']
+    })
   })
 
   it('handles uncc-ing another user with /uncc username', async () => {
     issueCommentEvent.comment.body = '/uncc some-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .delete('/repos/Codertocat/Hello-World/pulls/1/requested_reviewers', body => {
-        expect(body).toMatchObject({
-          reviewers: ['some-user']
-        })
-        return true
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      reviewers: ['some-user']
+    })
   })
 
   it('handles uncc-ing multiple users', async () => {
     issueCommentEvent.comment.body = '/uncc @some-user @other-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .delete('/repos/Codertocat/Hello-World/pulls/1/requested_reviewers', body => {
-        expect(body).toMatchObject({
-          reviewers: ['some-user', 'other-user']
-        })
-        return true
-      })
-      .reply(201)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      reviewers: ['some-user', 'other-user']
+    })
   })
 
   it('unccs user if they are an org member', async () => {
     issueCommentEvent.comment.body = '/uncc @some-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/Codertocat')
-      .reply(204)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .delete('/repos/Codertocat/Hello-World/pulls/1/requested_reviewers', body => {
-        expect(body).toMatchObject({
-          reviewers: ['some-user']
-        })
-        return true
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      reviewers: ['some-user']
+    })
   })
 
   it('uncc user if they are a repo collaborator', async () => {
     issueCommentEvent.comment.body = '/uncc @some-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/Codertocat')
-      .reply(404)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(204)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(404)
-
-    nock(utils.api)
-      .delete('/repos/Codertocat/Hello-World/pulls/1/requested_reviewers', body => {
-        expect(body).toMatchObject({
-          reviewers: ['some-user']
-        })
-        return true
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      reviewers: ['some-user']
+    })
   })
 
   it('uncc user if they have previously commented', async () => {
     issueCommentEvent.comment.body = '/uncc @some-user'
 
-    nock(utils.api)
-      .get('/orgs/Codertocat/members/Codertocat')
-      .reply(404)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, issueListComments)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1/comments')
-      .reply(200, issueListComments)
-
-    nock(utils.api)
-      .delete('/repos/Codertocat/Hello-World/pulls/1/requested_reviewers', body => {
-        expect(body).toMatchObject({
-          reviewers: ['some-user']
-        })
-        return true
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
-    expect.assertions(2)
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
+      reviewers: ['some-user']
+    })
   })
 })

--- a/__tests__/label/area.test.ts
+++ b/__tests__/label/area.test.ts
@@ -1,16 +1,21 @@
-import nock from 'nock'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
 
-import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
+import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 import * as utils from '../testUtils'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import labelFileContents from '../fixtures/labels/labelFileContentsResp.json'
 
-nock.disableNetConnect()
+const server = setupServer()
+beforeAll(() => server.listen({
+  onUnhandledRequest: 'warn',
+}))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 describe('area', () => {
   beforeEach(() => {
-    nock.cleanAll()
     utils.setupActionsEnv('/area')
   })
 
@@ -18,68 +23,65 @@ describe('area', () => {
     issueCommentEvent.comment.body = '/area important'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    let parsedBody = undefined
-    const scope = nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', body => {
-        parsedBody = body
-        return body
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/.github/labels.yaml')
-      .reply(200, labelFileContents)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(200, labelFileContents)),
+    )
 
     await handleIssueComment(commentContext)
-    expect(parsedBody).toEqual({
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
       labels: ['area/important']
     })
-    expect(scope.isDone()).toBe(true)
   })
 
   it('handles multiple area labels', async () => {
     issueCommentEvent.comment.body = '/area bug important'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    let parsedBody = undefined
-    const scope = nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', body => {
-        parsedBody = body
-        return body
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/.github/labels.yaml')
-      .reply(200, labelFileContents)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(200, labelFileContents)),
+    )
 
     await handleIssueComment(commentContext)
-    expect(parsedBody).toEqual({
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
       labels: ['area/bug', 'area/important']
     })
-    expect(scope.isDone()).toBe(true)
   })
 
   it('only adds area labels for files in .github/labels.yaml', async () => {
     issueCommentEvent.comment.body = '/area bug bad important'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    let parsedBody = undefined
-    const scope = nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', body => {
-        parsedBody = body
-        return body
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/.github/labels.yaml')
-      .reply(200, labelFileContents)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(200, labelFileContents)),
+    )
 
     await handleIssueComment(commentContext)
-    expect(parsedBody).toEqual({
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
       labels: ['area/bug', 'area/important']
     })
-    expect(scope.isDone()).toBe(true)
   })
 })

--- a/__tests__/label/area.test.ts
+++ b/__tests__/label/area.test.ts
@@ -1,16 +1,18 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
-import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
 import * as utils from '../testUtils'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import labelFileContents from '../fixtures/labels/labelFileContentsResp.json'
 
 const server = setupServer()
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -23,15 +25,19 @@ describe('area', () => {
     issueCommentEvent.comment.body = '/area important'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
-        utils.mockResponse(200, labelFileContents)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(200, labelFileContents)
+      )
     )
 
     await handleIssueComment(commentContext)
@@ -45,15 +51,19 @@ describe('area', () => {
     issueCommentEvent.comment.body = '/area bug important'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
-        utils.mockResponse(200, labelFileContents)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(200, labelFileContents)
+      )
     )
 
     await handleIssueComment(commentContext)
@@ -67,15 +77,19 @@ describe('area', () => {
     issueCommentEvent.comment.body = '/area bug bad important'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
-        utils.mockResponse(200, labelFileContents)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(200, labelFileContents)
+      )
     )
 
     await handleIssueComment(commentContext)

--- a/__tests__/label/hold.test.ts
+++ b/__tests__/label/hold.test.ts
@@ -1,16 +1,18 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
-import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
 import * as utils from '../testUtils'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import issuePayload from '../fixtures/issues/issue.json'
 
 const server = setupServer()
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -23,10 +25,12 @@ describe('hold', () => {
     issueCommentEvent.comment.body = '/hold'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     await handleIssueComment(commentContext)
@@ -41,26 +45,30 @@ describe('hold', () => {
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     issuePayload.labels.push({
-      "id": 1,
-      "node_id": "123",
-      "url": "https://api.github.com/repos/octocat/Hello-World/labels/lgtm",
-      "name": "hold",
-      "description": "looks good to me",
-      "color": "f29513",
-      "default": true
+      id: 1,
+      node_id: '123',
+      url: 'https://api.github.com/repos/octocat/Hello-World/labels/lgtm',
+      name: 'hold',
+      description: 'looks good to me',
+      color: 'f29513',
+      default: true
     })
 
-    const observeReqDelete = new utils.observeRequest
-    const observeReqGet = new utils.observeRequest
+    const observeReqDelete = new utils.observeRequest()
+    const observeReqGet = new utils.observeRequest()
     server.use(
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/hold`,
-        utils.mockResponse(200, null, observeReqDelete)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
-        utils.mockResponse(200, issuePayload, observeReqGet)),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/hold`,
+        utils.mockResponse(200, null, observeReqDelete)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issuePayload, observeReqGet)
+      )
     )
 
     await handleIssueComment(commentContext)
-    await expect(observeReqDelete.called()).resolves.toBe("called")
-    await expect(observeReqGet.called()).resolves.toBe("called")
+    await expect(observeReqDelete.called()).resolves.toBe('called')
+    await expect(observeReqGet.called()).resolves.toBe('called')
   })
 })

--- a/__tests__/label/hold.test.ts
+++ b/__tests__/label/hold.test.ts
@@ -1,16 +1,21 @@
-import nock from 'nock'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
 
-import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
+import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 import * as utils from '../testUtils'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import issuePayload from '../fixtures/issues/issue.json'
 
-nock.disableNetConnect()
+const server = setupServer()
+beforeAll(() => server.listen({
+  onUnhandledRequest: 'warn',
+}))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 describe('hold', () => {
   beforeEach(() => {
-    nock.cleanAll()
     utils.setupActionsEnv('/hold')
   })
 
@@ -18,19 +23,17 @@ describe('hold', () => {
     issueCommentEvent.comment.body = '/hold'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    let parsedBody = undefined
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', body => {
-        parsedBody = body
-        return body
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     await handleIssueComment(commentContext)
-    expect(parsedBody).toEqual({
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
       labels: ['hold']
     })
-    expect(nock.isDone()).toBe(true)
   })
 
   it('removes the hold label with /hold cancel', async () => {
@@ -47,15 +50,17 @@ describe('hold', () => {
       "default": true
     })
 
-    nock(utils.api)
-      .delete('/repos/Codertocat/Hello-World/issues/1/labels/hold')
-      .reply(200)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1')
-      .reply(200, issuePayload)
+    const observeReqDelete = new utils.observeRequest
+    const observeReqGet = new utils.observeRequest
+    server.use(
+      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/hold`,
+        utils.mockResponse(200, null, observeReqDelete)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issuePayload, observeReqGet)),
+    )
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
+    await expect(observeReqDelete.called()).resolves.toBe("called")
+    await expect(observeReqGet.called()).resolves.toBe("called")
   })
 })

--- a/__tests__/label/kind.test.ts
+++ b/__tests__/label/kind.test.ts
@@ -1,16 +1,21 @@
-import nock from 'nock'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
 
-import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
+import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 import * as utils from '../testUtils'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import labelFileContents from '../fixtures/labels/labelFileContentsResp.json'
 
-nock.disableNetConnect()
+const server = setupServer()
+beforeAll(() => server.listen({
+  onUnhandledRequest: 'warn',
+}))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 describe('kind', () => {
   beforeEach(() => {
-    nock.cleanAll()
     utils.setupActionsEnv('/kind')
   })
 
@@ -18,68 +23,65 @@ describe('kind', () => {
     issueCommentEvent.comment.body = '/kind cleanup'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    let parsedBody = undefined
-    const scope = nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', body => {
-        parsedBody = body
-        return body
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/.github/labels.yaml')
-      .reply(200, labelFileContents)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(200, labelFileContents)),
+    )
 
     await handleIssueComment(commentContext)
-    expect(parsedBody).toEqual({
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
       labels: ['kind/cleanup']
     })
-    expect(scope.isDone()).toBe(true)
   })
 
   it('handles multiple kind labels', async () => {
     issueCommentEvent.comment.body = '/kind cleanup failing-test'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    let parsedBody = undefined
-    const scope = nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', body => {
-        parsedBody = body
-        return body
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/.github/labels.yaml')
-      .reply(200, labelFileContents)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(200, labelFileContents)),
+    )
 
     await handleIssueComment(commentContext)
-    expect(parsedBody).toEqual({
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
       labels: ['kind/cleanup', 'kind/failing-test']
     })
-    expect(scope.isDone()).toBe(true)
   })
 
   it('only adds kind labels for files in .github/labels.yaml', async () => {
     issueCommentEvent.comment.body = '/kind cleanup bad failing-test'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    let parsedBody = undefined
-    const scope = nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', body => {
-        parsedBody = body
-        return body
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/.github/labels.yaml')
-      .reply(200, labelFileContents)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(200, labelFileContents)),
+    )
 
     await handleIssueComment(commentContext)
-    expect(parsedBody).toEqual({
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
       labels: ['kind/cleanup', 'kind/failing-test']
     })
-    expect(scope.isDone()).toBe(true)
   })
 })

--- a/__tests__/label/kind.test.ts
+++ b/__tests__/label/kind.test.ts
@@ -1,16 +1,18 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
-import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
 import * as utils from '../testUtils'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import labelFileContents from '../fixtures/labels/labelFileContentsResp.json'
 
 const server = setupServer()
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -23,15 +25,19 @@ describe('kind', () => {
     issueCommentEvent.comment.body = '/kind cleanup'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
-        utils.mockResponse(200, labelFileContents)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(200, labelFileContents)
+      )
     )
 
     await handleIssueComment(commentContext)
@@ -45,15 +51,19 @@ describe('kind', () => {
     issueCommentEvent.comment.body = '/kind cleanup failing-test'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
-        utils.mockResponse(200, labelFileContents)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(200, labelFileContents)
+      )
     )
 
     await handleIssueComment(commentContext)
@@ -67,15 +77,19 @@ describe('kind', () => {
     issueCommentEvent.comment.body = '/kind cleanup bad failing-test'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
-        utils.mockResponse(200, labelFileContents)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(200, labelFileContents)
+      )
     )
 
     await handleIssueComment(commentContext)

--- a/__tests__/label/lgtm.test.ts
+++ b/__tests__/label/lgtm.test.ts
@@ -1,7 +1,7 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
-import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
 
 import * as utils from '../testUtils'
 
@@ -9,9 +9,11 @@ import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import issuePayload from '../fixtures/issues/issue.json'
 
 const server = setupServer()
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -24,19 +26,27 @@ describe('lgtm', () => {
     issueCommentEvent.comment.body = '/lgtm'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404)
+      )
     )
 
     await handleIssueComment(commentContext)
@@ -61,16 +71,26 @@ describe('lgtm', () => {
     })
 
     server.use(
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,
-        utils.mockResponse(200)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
-        utils.mockResponse(200, issuePayload)),
-      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
-        utils.mockResponse(404)),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,
+        utils.mockResponse(200)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issuePayload)
+      ),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404)
+      )
     )
 
     await handleIssueComment(commentContext)
@@ -80,19 +100,27 @@ describe('lgtm', () => {
     issueCommentEvent.comment.body = '/lgtm'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(204)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404)
+      )
     )
 
     await handleIssueComment(commentContext)
@@ -120,17 +148,21 @@ approvers:
     }
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
-        utils.mockResponse(200, contentResponse)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(200, contentResponse)
+      )
     )
 
     const wantErr = `Codertocat is not included in the reviewers role in the OWNERS file`
 
     // Mock the reply that the user is not authorized
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     issueCommentEvent.comment.body = '/lgtm'
@@ -145,19 +177,27 @@ approvers:
     const wantErr = `Codertocat is not a org member or collaborator`
 
     // Mock the reply that the user is not authorized
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     server.use(
-      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(404)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404)
+      )
     )
 
     issueCommentEvent.comment.body = '/lgtm'
@@ -172,10 +212,12 @@ approvers:
     issueCommentEvent.comment.body = '/lgtm'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     const owners = Buffer.from(
@@ -195,8 +237,10 @@ reviewers:
     }
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
-        utils.mockResponse(200, contentResponse)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(200, contentResponse)
+      )
     )
 
     await handleIssueComment(commentContext)

--- a/__tests__/label/lgtm.test.ts
+++ b/__tests__/label/lgtm.test.ts
@@ -1,53 +1,47 @@
-import nock from 'nock'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
 
-import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
+import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 
 import * as utils from '../testUtils'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import issuePayload from '../fixtures/issues/issue.json'
 
-nock.disableNetConnect()
+const server = setupServer()
+beforeAll(() => server.listen({
+  onUnhandledRequest: 'warn',
+}))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 describe('lgtm', () => {
   beforeEach(() => {
-    nock.cleanAll()
     utils.setupActionsEnv('/lgtm')
-  })
-  afterEach(() => {
-    if (!nock.isDone()) {
-      throw new Error(
-        `Not all nock interceptors were used: ${JSON.stringify(
-          nock.pendingMocks()
-        )}`
-      )
-    }
   })
 
   it('labels the issue with the lgtm label', async () => {
     issueCommentEvent.comment.body = '/lgtm'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    let parsedBody = undefined
-    const scope = nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', body => {
-        parsedBody = body
-        return body
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
-    nock(utils.api).get('/orgs/Codertocat/members/Codertocat').reply(204)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/OWNERS')
-      .reply(404)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404)),
+    )
 
     await handleIssueComment(commentContext)
-    expect(parsedBody).toEqual({
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
       labels: ['lgtm']
     })
   })
@@ -66,23 +60,18 @@ describe('lgtm', () => {
       default: true
     })
 
-    nock(utils.api)
-      .delete('/repos/Codertocat/Hello-World/issues/1/labels/lgtm')
-      .reply(200)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1')
-      .reply(200, issuePayload)
-
-    nock(utils.api).get('/orgs/Codertocat/members/Codertocat').reply(204)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/OWNERS')
-      .reply(404)
+    server.use(
+      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,
+        utils.mockResponse(200)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issuePayload)),
+      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404)),
+    )
 
     await handleIssueComment(commentContext)
   })
@@ -91,26 +80,24 @@ describe('lgtm', () => {
     issueCommentEvent.comment.body = '/lgtm'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    let parsedBody = undefined
-    const scope = nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', body => {
-        parsedBody = body
-        return body
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
-    nock(utils.api).get('/orgs/Codertocat/members/Codertocat').reply(404)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(204)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/OWNERS')
-      .reply(404)
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404)),
+    )
 
     await handleIssueComment(commentContext)
-    expect(parsedBody).toEqual({
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
       labels: ['lgtm']
     })
   })
@@ -131,57 +118,65 @@ approvers:
       path: 'OWNERS',
       content: owners
     }
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/OWNERS')
-      .reply(200, contentResponse)
+
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(200, contentResponse)),
+    )
 
     const wantErr = `Codertocat is not included in the reviewers role in the OWNERS file`
 
     // Mock the reply that the user is not authorized
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/comments', (req) => {
-        expect(req.body).toContain(wantErr)
-        return true
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     issueCommentEvent.comment.body = '/lgtm'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(observeReq.body().body).toContain(wantErr)
   })
 
   it('fails if commenter is not org member or collaborator', async () => {
     const wantErr = `Codertocat is not a org member or collaborator`
 
     // Mock the reply that the user is not authorized
-    nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/comments', (req) => {
-        expect(req.body).toContain(wantErr)
-        return true
-      })
-      .reply(200)
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/OWNERS')
-      .reply(404)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, null, observeReq)),
+    )
+
+    server.use(
+      rest.get(`${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404)),
+    )
 
     issueCommentEvent.comment.body = '/lgtm'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(observeReq.body().body).toContain(wantErr)
   })
 
   it('adds label if commenter is reviewer in OWNERS', async () => {
     issueCommentEvent.comment.body = '/lgtm'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    let parsedBody = undefined
-    const scope = nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', body => {
-        parsedBody = body
-        return body
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
     const owners = Buffer.from(
       `
@@ -198,12 +193,15 @@ reviewers:
       path: 'OWNERS',
       content: owners
     }
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/OWNERS')
-      .reply(200, contentResponse)
+
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(200, contentResponse)),
+    )
 
     await handleIssueComment(commentContext)
-    expect(parsedBody).toEqual({
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
       labels: ['lgtm']
     })
   })

--- a/__tests__/label/priority.test.ts
+++ b/__tests__/label/priority.test.ts
@@ -1,16 +1,21 @@
-import nock from 'nock'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
 
-import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
+import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 import * as utils from '../testUtils'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import labelFileContents from '../fixtures/labels/labelFileContentsResp.json'
 
-nock.disableNetConnect()
+const server = setupServer()
+beforeAll(() => server.listen({
+  onUnhandledRequest: 'warn',
+}))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 describe('priority', () => {
   beforeEach(() => {
-    nock.cleanAll()
     utils.setupActionsEnv('/priority')
   })
 
@@ -18,68 +23,65 @@ describe('priority', () => {
     issueCommentEvent.comment.body = '/priority low'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    let parsedBody = undefined
-    const scope = nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', body => {
-        parsedBody = body
-        return body
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/.github/labels.yaml')
-      .reply(200, labelFileContents)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(200, labelFileContents)),
+    )
 
     await handleIssueComment(commentContext)
-    expect(parsedBody).toEqual({
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
       labels: ['priority/low']
     })
-    expect(scope.isDone()).toBe(true)
   })
 
   it('handles multiple priority labels', async () => {
     issueCommentEvent.comment.body = '/priority low high'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    let parsedBody = undefined
-    const scope = nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', body => {
-        parsedBody = body
-        return body
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/.github/labels.yaml')
-      .reply(200, labelFileContents)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(200, labelFileContents)),
+    )
 
     await handleIssueComment(commentContext)
-    expect(parsedBody).toEqual({
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
       labels: ['priority/low', 'priority/high']
     })
-    expect(scope.isDone()).toBe(true)
   })
 
   it('only adds priority labels for files in .github/labels.yaml', async () => {
     issueCommentEvent.comment.body = '/priority low mid high'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    let parsedBody = undefined
-    const scope = nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', body => {
-        parsedBody = body
-        return body
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/.github/labels.yaml')
-      .reply(200, labelFileContents)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(200, labelFileContents)),
+    )
 
     await handleIssueComment(commentContext)
-    expect(parsedBody).toEqual({
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
       labels: ['priority/low', 'priority/high']
     })
-    expect(scope.isDone()).toBe(true)
   })
 })

--- a/__tests__/label/priority.test.ts
+++ b/__tests__/label/priority.test.ts
@@ -1,16 +1,18 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
-import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
 import * as utils from '../testUtils'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import labelFileContents from '../fixtures/labels/labelFileContentsResp.json'
 
 const server = setupServer()
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -23,15 +25,19 @@ describe('priority', () => {
     issueCommentEvent.comment.body = '/priority low'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
-        utils.mockResponse(200, labelFileContents)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(200, labelFileContents)
+      )
     )
 
     await handleIssueComment(commentContext)
@@ -45,15 +51,19 @@ describe('priority', () => {
     issueCommentEvent.comment.body = '/priority low high'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
-        utils.mockResponse(200, labelFileContents)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(200, labelFileContents)
+      )
     )
 
     await handleIssueComment(commentContext)
@@ -67,15 +77,19 @@ describe('priority', () => {
     issueCommentEvent.comment.body = '/priority low mid high'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
-        utils.mockResponse(200, labelFileContents)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(200, labelFileContents)
+      )
     )
 
     await handleIssueComment(commentContext)

--- a/__tests__/label/remove.test.ts
+++ b/__tests__/label/remove.test.ts
@@ -1,17 +1,22 @@
-import nock from 'nock'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
 
-import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
+import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 import * as utils from '../testUtils'
 import * as core from '@actions/core'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import issuePayload from '../fixtures/issues/issue.json'
 
-nock.disableNetConnect()
+const server = setupServer()
+beforeAll(() => server.listen({
+  onUnhandledRequest: 'warn',
+}))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 describe('remove', () => {
   beforeEach(() => {
-    nock.cleanAll()
     utils.setupActionsEnv('/remove')
   })
 
@@ -19,61 +24,48 @@ describe('remove', () => {
     issueCommentEvent.comment.body = '/remove some-label'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    nock(utils.api)
-      .delete('/repos/Codertocat/Hello-World/issues/1/labels/some-label')
-      .reply(200)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1')
-      .reply(200, issuePayload)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(204)
+    server.use(
+      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/some-label`,
+        utils.mockResponse(200)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issuePayload)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)),
+    )
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
   })
 
   it('removes multiple labels', async () => {
     issueCommentEvent.comment.body = '/remove some-label some-other-label'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    nock(utils.api)
-      .delete('/repos/Codertocat/Hello-World/issues/1/labels/some-label')
-      .reply(200)
-
-    nock(utils.api)
-      .delete('/repos/Codertocat/Hello-World/issues/1/labels/some-other-label')
-      .reply(200)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1')
-      .reply(200, issuePayload)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(204)
+    server.use(
+      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/some-label`,
+        utils.mockResponse(200)),
+      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/some-other-label`,
+        utils.mockResponse(200)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issuePayload)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)),
+    )
 
     await handleIssueComment(commentContext)
-    expect(nock.isDone()).toBe(true)
   })
 
   it('fails if commenter is not collaborator', async () => {
     issueCommentEvent.comment.body = '/remove some-label'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    nock(utils.api)
-      .delete('/repos/Codertocat/Hello-World/issues/1/labels/some-label')
-      .reply(200)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/issues/1')
-      .reply(200, issuePayload)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/collaborators/Codertocat')
-      .reply(404)
+    server.use(
+      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/some-label`,
+        utils.mockResponse(200)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issuePayload)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)),
+    )
 
     const spy = jest.spyOn(core, 'setFailed')
     await handleIssueComment(commentContext)

--- a/__tests__/label/remove.test.ts
+++ b/__tests__/label/remove.test.ts
@@ -1,7 +1,7 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
-import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
 import * as utils from '../testUtils'
 import * as core from '@actions/core'
 
@@ -9,9 +9,11 @@ import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import issuePayload from '../fixtures/issues/issue.json'
 
 const server = setupServer()
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -25,12 +27,18 @@ describe('remove', () => {
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     server.use(
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/some-label`,
-        utils.mockResponse(200)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
-        utils.mockResponse(200, issuePayload)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(204)),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/some-label`,
+        utils.mockResponse(200)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issuePayload)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)
+      )
     )
 
     await handleIssueComment(commentContext)
@@ -41,14 +49,22 @@ describe('remove', () => {
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     server.use(
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/some-label`,
-        utils.mockResponse(200)),
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/some-other-label`,
-        utils.mockResponse(200)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
-        utils.mockResponse(200, issuePayload)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(204)),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/some-label`,
+        utils.mockResponse(200)
+      ),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/some-other-label`,
+        utils.mockResponse(200)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issuePayload)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204)
+      )
     )
 
     await handleIssueComment(commentContext)
@@ -59,12 +75,18 @@ describe('remove', () => {
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     server.use(
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/some-label`,
-        utils.mockResponse(200)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
-        utils.mockResponse(200, issuePayload)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
-        utils.mockResponse(404)),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/some-label`,
+        utils.mockResponse(200)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issuePayload)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404)
+      )
     )
 
     const spy = jest.spyOn(core, 'setFailed')

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -20,10 +20,17 @@ test('runs with no options', () => {
       'not yet supported'
     )
   } catch (e) {
-    console.log(
-      "Calling the github action's main function without any context failed:",
-      e.output.toString()
-    )
+    if (
+      typeof e === 'object' &&
+      e &&
+      'output' in e &&
+      typeof e.output === 'string'
+    ) {
+      console.log(
+        "Calling the github action's main function without any context failed:",
+        e.output.toString()
+      )
+    }
     throw e
   }
 })

--- a/__tests__/pullReqTest/handlePullReq.test.ts
+++ b/__tests__/pullReqTest/handlePullReq.test.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core'
 import * as utils from '../testUtils'
 
-import {handlePullReq} from '../../src/pullReq/handlePullReq'
+import { handlePullReq } from '../../src/pullReq/handlePullReq'
 
 import prCreatedEvent from '../fixtures/pullReq/pullReqOpenedEvent.json'
 

--- a/__tests__/pullReqTest/handlePullReq.test.ts
+++ b/__tests__/pullReqTest/handlePullReq.test.ts
@@ -1,17 +1,17 @@
 import * as core from '@actions/core'
 import * as utils from '../testUtils'
 
-import { handlePullReq } from '../../src/pullReq/handlePullReq'
+import {handlePullReq} from '../../src/pullReq/handlePullReq'
 
 import prCreatedEvent from '../fixtures/pullReq/pullReqOpenedEvent.json'
 
 it('ignores the jobs if not setup in environment', async () => {
-  const spy = jest.spyOn(core, 'setFailed');
+  const spy = jest.spyOn(core, 'setFailed')
 
   utils.setupActionsEnv('/assign')
 
   const runContext = new utils.mockContext(prCreatedEvent)
 
   await handlePullReq(runContext)
-  expect(spy).toHaveBeenCalled();
+  expect(spy).toHaveBeenCalled()
 })

--- a/__tests__/pullReqTest/onPrLgtm.test.ts
+++ b/__tests__/pullReqTest/onPrLgtm.test.ts
@@ -1,16 +1,18 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
-import { handlePullReq } from '../../src/pullReq/handlePullReq'
+import {handlePullReq} from '../../src/pullReq/handlePullReq'
 import * as utils from '../testUtils'
 
 import pullReqEvent from '../fixtures/pullReq/pullReqOpenedEvent.json'
 import issuePayload from '../fixtures/issues/issue.json'
 
 const server = setupServer()
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -23,20 +25,24 @@ describe('onPrLgtm', () => {
     const prContext = new utils.mockContext(pullReqEvent)
 
     issuePayload.labels.push({
-      "id": 1999,
-      "node_id": "MEOW111=",
-      "url": "https://api.github.com/repos/octocat/Hello-World/labels/lgtm",
-      "name": "lgtm",
-      "description": "looks good to me",
-      "color": "f29513",
-      "default": false
+      id: 1999,
+      node_id: 'MEOW111=',
+      url: 'https://api.github.com/repos/octocat/Hello-World/labels/lgtm',
+      name: 'lgtm',
+      description: 'looks good to me',
+      color: 'f29513',
+      default: false
     })
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/issues/1`,
-        utils.mockResponse(200, issuePayload)),
-      rest.delete(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,
-        utils.mockResponse(200)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issuePayload)
+      ),
+      rest.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,
+        utils.mockResponse(200)
+      )
     )
 
     await expect(handlePullReq(prContext)).resolves.not.toThrowError()

--- a/__tests__/testUtils.ts
+++ b/__tests__/testUtils.ts
@@ -28,3 +28,51 @@ export const setupJobsEnv = (arg: string = '') => {
   process.env['INPUT_JOBS'] = arg
   process.env['INPUT_GITHUB-TOKEN'] = 'some-token'
 }
+
+export class observeRequest {
+  private _ref: any = {}
+
+  public set ref(req: any) {
+    this._ref = req
+  }
+
+  public get ref() {
+    return this._ref
+  }
+
+  public body() {
+    const decoder = new TextDecoder('utf-8')
+
+    return JSON.parse(decoder.decode(this._ref?._body))
+  }
+
+  public called() {
+    const obj = this
+    return new Promise(resolve => {
+      const interval = setInterval(() => {
+        if ('method' in obj.ref) {
+          resolve('called')
+          clearInterval(interval)
+        }
+      }, 1)
+    })
+  }
+}
+
+export const mockResponse = (
+  replyCode: number,
+  replyBody?: any,
+  observeReq?: observeRequest
+) => {
+  return (req: any, res: any, ctx: any) => {
+    if (observeReq instanceof observeRequest) {
+      observeReq.ref = req
+    }
+
+    if (replyBody) {
+      return res(ctx.status(replyCode), ctx.json(replyBody))
+    } else {
+      return res(ctx.status(replyCode))
+    }
+  }
+}

--- a/__tests__/utils/labeling.test.ts
+++ b/__tests__/utils/labeling.test.ts
@@ -1,10 +1,9 @@
-import { setupServer } from 'msw/node'
-import { rest } from 'msw'
+import {setupServer} from 'msw/node'
+import {rest} from 'msw'
 
 import * as core from '@actions/core'
 
-
-import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
 import * as utils from '../testUtils'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
@@ -12,9 +11,11 @@ import labelFileContents from '../fixtures/labels/labelFileContentsResp.json'
 import malformedFileContents from '../fixtures/labels/labelFileMalformedResponse.json'
 
 const server = setupServer()
-beforeAll(() => server.listen({
-  onUnhandledRequest: 'warn',
-}))
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'warn'
+  })
+)
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -27,17 +28,23 @@ describe('utils labeling', () => {
     issueCommentEvent.comment.body = '/area important'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    const observeReq = new utils.observeRequest
+    const observeReq = new utils.observeRequest()
     server.use(
-      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
-        utils.mockResponse(200, null, observeReq)),
+      rest.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)
+      )
     )
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yml`,
-        utils.mockResponse(200, labelFileContents)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yml`,
+        utils.mockResponse(200, labelFileContents)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(404)
+      )
     )
 
     await handleIssueComment(commentContext)
@@ -48,20 +55,24 @@ describe('utils labeling', () => {
   })
 
   it('can error correctly on malformed label.yaml', async () => {
-    const spy = jest.spyOn(core, 'setFailed');
+    const spy = jest.spyOn(core, 'setFailed')
 
     issueCommentEvent.comment.body = '/area important'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
     server.use(
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yml`,
-        utils.mockResponse(200, malformedFileContents)),
-      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
-        utils.mockResponse(404)),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yml`,
+        utils.mockResponse(200, malformedFileContents)
+      ),
+      rest.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(404)
+      )
     )
 
     await handleIssueComment(commentContext)
 
-    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalled()
   })
 })

--- a/__tests__/utils/labeling.test.ts
+++ b/__tests__/utils/labeling.test.ts
@@ -1,19 +1,25 @@
-import nock from 'nock'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
+
 import * as core from '@actions/core'
 
 
-import {handleIssueComment} from '../../src/issueComment/handleIssueComment'
+import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 import * as utils from '../testUtils'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import labelFileContents from '../fixtures/labels/labelFileContentsResp.json'
 import malformedFileContents from '../fixtures/labels/labelFileMalformedResponse.json'
 
-nock.disableNetConnect()
+const server = setupServer()
+beforeAll(() => server.listen({
+  onUnhandledRequest: 'warn',
+}))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 describe('utils labeling', () => {
   beforeEach(() => {
-    nock.cleanAll()
     utils.setupActionsEnv('/area')
   })
 
@@ -21,27 +27,24 @@ describe('utils labeling', () => {
     issueCommentEvent.comment.body = '/area important'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    let parsedBody = undefined
-    const scope = nock(utils.api)
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', body => {
-        parsedBody = body
-        return body
-      })
-      .reply(200)
+    const observeReq = new utils.observeRequest
+    server.use(
+      rest.post(`${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq)),
+    )
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/.github/labels.yml')
-      .reply(200, labelFileContents)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/.github/labels.yaml')
-      .reply(404)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yml`,
+        utils.mockResponse(200, labelFileContents)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(404)),
+    )
 
     await handleIssueComment(commentContext)
-    expect(parsedBody).toEqual({
+    await observeReq.called()
+    expect(observeReq.body()).toMatchObject({
       labels: ['area/important']
     })
-    expect(scope.isDone()).toBe(true)
   })
 
   it('can error correctly on malformed label.yaml', async () => {
@@ -50,13 +53,12 @@ describe('utils labeling', () => {
     issueCommentEvent.comment.body = '/area important'
     const commentContext = new utils.mockContext(issueCommentEvent)
 
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/.github/labels.yml')
-      .reply(200, malformedFileContents)
-
-    nock(utils.api)
-      .get('/repos/Codertocat/Hello-World/contents/.github/labels.yaml')
-      .reply(404)
+    server.use(
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yml`,
+        utils.mockResponse(200, malformedFileContents)),
+      rest.get(`${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(404)),
+    )
 
     await handleIssueComment(commentContext)
 

--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ branding:
   color: blue
   icon: anchor
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,10 +21,11 @@
         "@types/js-yaml": "^4.0.5",
         "@types/minimatch": "^5.1.2",
         "@types/node": "^20.5.1",
-        "@typescript-eslint/eslint-plugin": "^6.4.0",
-        "@typescript-eslint/parser": "^6.4.0",
-        "@zeit/ncc": "^0.20.5",
-        "eslint": "^8.47.0",
+        "@typescript-eslint/eslint-plugin": "^6.7.0",
+        "@typescript-eslint/parser": "^6.7.0",
+        "@vercel/ncc": "^0.38.0",
+        "eslint": "^8.49.0",
+        "eslint-import-resolver-typescript": "^3.6.0",
         "eslint-plugin-github": "^4.9.2",
         "eslint-plugin-import": "^2.28.1",
         "eslint-plugin-jest": "^27.2.3",
@@ -32,10 +33,10 @@
         "jest": "^29.6.2",
         "jest-circus": "^29.6.2",
         "js-yaml": "^4.1.0",
-        "nock": "^13.3.3",
+        "msw": "^1.3.1",
         "prettier": "^3.0.2",
         "ts-jest": "^29.1.1",
-        "typescript": "^5.1.6"
+        "typescript": "^5.2.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -825,9 +826,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.47.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.47.0.tgz",
-      "integrity": "sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.49.0.tgz",
+      "integrity": "sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -840,9 +841,9 @@
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
+      "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -1328,6 +1329,47 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mswjs/cookies": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.2.2.tgz",
+      "integrity": "sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==",
+      "dev": true,
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.0",
+        "set-cookie-parser": "^2.4.6"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.17.10",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.10.tgz",
+      "integrity": "sha512-N8x7eSLGcmUFNWZRxT1vsHvypzIRgQYdG0rJey/rZCy6zT/30qDt8Joj7FxzGNLSwXbeZqJOMqDurp7ra4hgbw==",
+      "dev": true,
+      "dependencies": {
+        "@open-draft/until": "^1.0.3",
+        "@types/debug": "^4.1.7",
+        "@xmldom/xmldom": "^0.8.3",
+        "debug": "^4.3.3",
+        "headers-polyfill": "3.2.5",
+        "outvariant": "^1.2.1",
+        "strict-event-emitter": "^0.2.4",
+        "web-encoding": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/strict-event-emitter": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz",
+      "integrity": "sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==",
+      "dev": true,
+      "dependencies": {
+        "events": "^3.3.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1740,6 +1782,12 @@
         "node": ">= 18"
       }
     },
+    "node_modules/@open-draft/until": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
+      "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
+      "dev": true
+    },
     "node_modules/@pkgr/utils": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
@@ -1825,6 +1873,21 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
+      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -1868,6 +1931,12 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/js-levenshtein": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz",
+      "integrity": "sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==",
+      "dev": true
+    },
     "node_modules/@types/js-yaml": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
@@ -1892,6 +1961,12 @@
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true
     },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "20.5.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.1.tgz",
@@ -1903,6 +1978,15 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
+    },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.3.tgz",
+      "integrity": "sha512-7QhnH7bi+6KAhBB+Auejz1uV9DHiopZqu7LfR/5gZZTkejJV5nYeZZpgfFoE0N8aDsXuiYpfKyfyMatCwQhyTQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -1926,16 +2010,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.0.tgz",
-      "integrity": "sha512-62o2Hmc7Gs3p8SLfbXcipjWAa6qk2wZGChXG2JbBtYpwSRmti/9KHLqfbLs9uDigOexG+3PaQ9G2g3201FWLKg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.0.tgz",
+      "integrity": "sha512-gUqtknHm0TDs1LhY12K2NA3Rmlmp88jK9Tx8vGZMfHeNMLE3GH2e9TRub+y+SOjuYgtOmok+wt1AyDPZqxbNag==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.4.0",
-        "@typescript-eslint/type-utils": "6.4.0",
-        "@typescript-eslint/utils": "6.4.0",
-        "@typescript-eslint/visitor-keys": "6.4.0",
+        "@typescript-eslint/scope-manager": "6.7.0",
+        "@typescript-eslint/type-utils": "6.7.0",
+        "@typescript-eslint/utils": "6.7.0",
+        "@typescript-eslint/visitor-keys": "6.7.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -1961,15 +2045,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.0.tgz",
-      "integrity": "sha512-I1Ah1irl033uxjxO9Xql7+biL3YD7w9IU8zF+xlzD/YxY6a4b7DYA08PXUUCbm2sEljwJF6ERFy2kTGAGcNilg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.0.tgz",
+      "integrity": "sha512-jZKYwqNpNm5kzPVP5z1JXAuxjtl2uG+5NpaMocFPTNC2EdYIgbXIPImObOkhbONxtFTTdoZstLZefbaK+wXZng==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.4.0",
-        "@typescript-eslint/types": "6.4.0",
-        "@typescript-eslint/typescript-estree": "6.4.0",
-        "@typescript-eslint/visitor-keys": "6.4.0",
+        "@typescript-eslint/scope-manager": "6.7.0",
+        "@typescript-eslint/types": "6.7.0",
+        "@typescript-eslint/typescript-estree": "6.7.0",
+        "@typescript-eslint/visitor-keys": "6.7.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1989,13 +2073,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.0.tgz",
-      "integrity": "sha512-TUS7vaKkPWDVvl7GDNHFQMsMruD+zhkd3SdVW0d7b+7Zo+bd/hXJQ8nsiUZMi1jloWo6c9qt3B7Sqo+flC1nig==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.0.tgz",
+      "integrity": "sha512-lAT1Uau20lQyjoLUQ5FUMSX/dS07qux9rYd5FGzKz/Kf8W8ccuvMyldb8hadHdK/qOI7aikvQWqulnEq2nCEYA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.0",
-        "@typescript-eslint/visitor-keys": "6.4.0"
+        "@typescript-eslint/types": "6.7.0",
+        "@typescript-eslint/visitor-keys": "6.7.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2006,13 +2090,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.4.0.tgz",
-      "integrity": "sha512-TvqrUFFyGY0cX3WgDHcdl2/mMCWCDv/0thTtx/ODMY1QhEiyFtv/OlLaNIiYLwRpAxAtOLOY9SUf1H3Q3dlwAg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.0.tgz",
+      "integrity": "sha512-f/QabJgDAlpSz3qduCyQT0Fw7hHpmhOzY/Rv6zO3yO+HVIdPfIWhrQoAyG+uZVtWAIS85zAyzgAFfyEr+MgBpg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.4.0",
-        "@typescript-eslint/utils": "6.4.0",
+        "@typescript-eslint/typescript-estree": "6.7.0",
+        "@typescript-eslint/utils": "6.7.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -2033,9 +2117,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.0.tgz",
-      "integrity": "sha512-+FV9kVFrS7w78YtzkIsNSoYsnOtrYVnKWSTVXoL1761CsCRv5wpDOINgsXpxD67YCLZtVQekDDyaxfjVWUJmmg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.0.tgz",
+      "integrity": "sha512-ihPfvOp7pOcN/ysoj0RpBPOx3HQTJTrIN8UZK+WFd3/iDeFHHqeyYxa4hQk4rMhsz9H9mXpR61IzwlBVGXtl9Q==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2046,13 +2130,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.0.tgz",
-      "integrity": "sha512-iDPJArf/K2sxvjOR6skeUCNgHR/tCQXBsa+ee1/clRKr3olZjZ/dSkXPZjG6YkPtnW6p5D1egeEPMCW6Gn4yLA==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.0.tgz",
+      "integrity": "sha512-dPvkXj3n6e9yd/0LfojNU8VMUGHWiLuBZvbM6V6QYD+2qxqInE7J+J/ieY2iGwR9ivf/R/haWGkIj04WVUeiSQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.0",
-        "@typescript-eslint/visitor-keys": "6.4.0",
+        "@typescript-eslint/types": "6.7.0",
+        "@typescript-eslint/visitor-keys": "6.7.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2073,17 +2157,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.0.tgz",
-      "integrity": "sha512-BvvwryBQpECPGo8PwF/y/q+yacg8Hn/2XS+DqL/oRsOPK+RPt29h5Ui5dqOKHDlbXrAeHUTnyG3wZA0KTDxRZw==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.0.tgz",
+      "integrity": "sha512-MfCq3cM0vh2slSikQYqK2Gq52gvOhe57vD2RM3V4gQRZYX4rDPnKLu5p6cm89+LJiGlwEXU8hkYxhqqEC/V3qA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.4.0",
-        "@typescript-eslint/types": "6.4.0",
-        "@typescript-eslint/typescript-estree": "6.4.0",
+        "@typescript-eslint/scope-manager": "6.7.0",
+        "@typescript-eslint/types": "6.7.0",
+        "@typescript-eslint/typescript-estree": "6.7.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -2098,12 +2182,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.0.tgz",
-      "integrity": "sha512-yJSfyT+uJm+JRDWYRYdCm2i+pmvXJSMtPR9Cq5/XQs4QIgNoLcoRtDdzsLbLsFM/c6um6ohQkg/MLxWvoIndJA==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.0.tgz",
+      "integrity": "sha512-/C1RVgKFDmGMcVGeD8HjKv2bd72oI1KxQDeY8uc66gw9R0OK0eMq48cA+jv9/2Ag6cdrsUGySm1yzYmfz0hxwQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.0",
+        "@typescript-eslint/types": "6.7.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -2114,15 +2198,30 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@zeit/ncc": {
-      "version": "0.20.5",
-      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.20.5.tgz",
-      "integrity": "sha512-XU6uzwvv95DqxciQx+aOLhbyBx/13ky+RK1y88Age9Du3BlA4mMPCy13BGjayOrrumOzlq1XV3SD/BWiZENXlw==",
-      "deprecated": "@zeit/ncc is no longer maintained. Please use @vercel/ncc instead.",
+    "node_modules/@vercel/ncc": {
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.0.tgz",
+      "integrity": "sha512-B4YKZMm/EqMptKSFyAq4q2SlgJe+VCmEH6Y8gf/E1pTlWbsUJpuH1ymik2Ex3aYO5mCWwV1kaSYHSQOT8+4vHA==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
       }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/acorn": {
       "version": "8.10.0",
@@ -2500,6 +2599,26 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/before-after-hook": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
@@ -2512,6 +2631,26 @@
       "dev": true,
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/bplist-parser": {
@@ -2597,6 +2736,30 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -2696,6 +2859,51 @@
         "node": ">=10"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
@@ -2725,6 +2933,39 @@
         "node": ">=6"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.1.tgz",
+      "integrity": "sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -2737,6 +2978,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/co": {
@@ -2784,6 +3034,15 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -2995,6 +3254,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -3102,6 +3373,19 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
+      "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -3227,16 +3511,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.47.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.47.0.tgz",
-      "integrity": "sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.49.0.tgz",
+      "integrity": "sha512-jw03ENfm6VJI0jA9U+8H5zfl5b+FvuU3YYvZRdZHOlU2ggJkxrlkJH4HcDrZpj6YwD8kuYqvQM8LyesoazrSOQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "^8.47.0",
-        "@humanwhocodes/config-array": "^0.11.10",
+        "@eslint/js": "8.49.0",
+        "@humanwhocodes/config-array": "^0.11.11",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.12.4",
@@ -3310,6 +3594,31 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.0.tgz",
+      "integrity": "sha512-QTHR9ddNnn35RTxlaEnx2gCxqFlF2SEN0SE2d17SqwyM7YOSI2GHWRYp5BiRkObTUNYPupC/3Fq2a0PpT+EKpg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "enhanced-resolve": "^5.12.0",
+        "eslint-module-utils": "^2.7.4",
+        "fast-glob": "^3.3.1",
+        "get-tsconfig": "^4.5.0",
+        "is-core-module": "^2.11.0",
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts/projects/eslint-import-resolver-ts"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*"
       }
     },
     "node_modules/eslint-module-utils": {
@@ -3893,6 +4202,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3940,6 +4258,20 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4010,6 +4342,30 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -4203,6 +4559,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.0.tgz",
+      "integrity": "sha512-pmjiZ7xtB8URYm74PlGJozDNyhvsVLUcpBa8DZBG3bWHwaHa9bPiRpiSfovw+fjhwONSCWKRyk+JQHEGZmMrzw==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -4331,6 +4699,15 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "node_modules/graphql": {
+      "version": "16.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.0.tgz",
+      "integrity": "sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -4412,6 +4789,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/headers-polyfill": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.2.5.tgz",
+      "integrity": "sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==",
+      "dev": true
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4426,6 +4809,38 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ignore": {
       "version": "5.2.4",
@@ -4504,6 +4919,46 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/inquirer": {
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
+      "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.5",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6",
+        "wrap-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
@@ -4516,6 +4971,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4548,6 +5019,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-boolean-object": {
@@ -4647,6 +5130,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -4677,6 +5175,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
@@ -4688,6 +5195,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -4813,6 +5326,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-weakref": {
@@ -5496,6 +6021,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5542,12 +6076,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
     },
     "node_modules/json5": {
@@ -5686,6 +6214,22 @@
       "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true
     },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5791,31 +6335,80 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/msw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-1.3.1.tgz",
+      "integrity": "sha512-GhP5lHSTXNlZb9EaKgPRJ01YAnVXwzkvnTzRn4W8fxU2DXuJrRO+Nb6OHdYqB4fCkwSNpIJH9JkON5Y6rHqJMQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mswjs/cookies": "^0.2.2",
+        "@mswjs/interceptors": "^0.17.10",
+        "@open-draft/until": "^1.0.3",
+        "@types/cookie": "^0.4.1",
+        "@types/js-levenshtein": "^1.1.1",
+        "chalk": "^4.1.1",
+        "chokidar": "^3.4.2",
+        "cookie": "^0.4.2",
+        "graphql": "^15.0.0 || ^16.0.0",
+        "headers-polyfill": "3.2.5",
+        "inquirer": "^8.2.0",
+        "is-node-process": "^1.2.0",
+        "js-levenshtein": "^1.1.6",
+        "node-fetch": "^2.6.7",
+        "outvariant": "^1.4.0",
+        "path-to-regexp": "^6.2.0",
+        "strict-event-emitter": "^0.4.3",
+        "type-fest": "^2.19.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.4.x <= 5.2.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "node_modules/nock": {
-      "version": "13.3.3",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.3.tgz",
-      "integrity": "sha512-z+KUlILy9SK/RjpeXDiDUEAq4T94ADPHE3qaRkf66mpEhzc/ytOMm3Bwdrbq6k1tMWkbdujiKim3G2tfQARuJw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.0",
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.21",
-        "propagate": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13"
-      }
-    },
     "node_modules/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6018,6 +6611,44 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.0.tgz",
+      "integrity": "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==",
+      "dev": true
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -6118,6 +6749,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -6295,15 +6932,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/propagate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
-      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -6354,6 +6982,32 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
     },
     "node_modules/regenerator-runtime": {
       "version": "0.14.0",
@@ -6434,6 +7088,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve.exports": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
@@ -6441,6 +7104,19 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reusify": {
@@ -6483,6 +7159,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6506,6 +7191,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.0.tgz",
@@ -6524,6 +7218,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -6537,6 +7251,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "node_modules/semver": {
       "version": "7.5.4",
@@ -6569,6 +7289,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
       "dev": true
     },
     "node_modules/shebang-command": {
@@ -6671,6 +7397,21 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
+      "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==",
+      "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -6843,6 +7584,15 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -6885,6 +7635,12 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true
+    },
     "node_modules/titleize": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
@@ -6895,6 +7651,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/tmpl": {
@@ -7151,9 +7919,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -7231,6 +7999,25 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -7266,6 +8053,27 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-encoding": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "dev": true,
+      "dependencies": {
+        "util": "^0.12.3"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "0.9.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -39,10 +39,11 @@
     "@types/js-yaml": "^4.0.5",
     "@types/minimatch": "^5.1.2",
     "@types/node": "^20.5.1",
-    "@typescript-eslint/eslint-plugin": "^6.4.0",
-    "@typescript-eslint/parser": "^6.4.0",
-    "@zeit/ncc": "^0.20.5",
-    "eslint": "^8.47.0",
+    "@typescript-eslint/eslint-plugin": "^6.7.0",
+    "@typescript-eslint/parser": "^6.7.0",
+    "@vercel/ncc": "^0.38.0",
+    "eslint": "^8.49.0",
+    "eslint-import-resolver-typescript": "^3.6.0",
     "eslint-plugin-github": "^4.9.2",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-jest": "^27.2.3",
@@ -50,9 +51,9 @@
     "jest": "^29.6.2",
     "jest-circus": "^29.6.2",
     "js-yaml": "^4.1.0",
-    "nock": "^13.3.3",
+    "msw": "^1.3.1",
     "prettier": "^3.0.2",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.1.6"
+    "typescript": "^5.2.2"
   }
 }

--- a/src/cronJobs/lgtm.ts
+++ b/src/cronJobs/lgtm.ts
@@ -1,23 +1,15 @@
 import * as github from '@actions/github'
-import {Octokit} from '@octokit/rest'
+import { Octokit } from '@octokit/rest'
+import { Endpoints } from '@octokit/types'
 
-import * as types from '@octokit/types'
-
-import {Context} from '@actions/github/lib/context'
+import { Context } from '@actions/github/lib/context'
 import * as core from '@actions/core'
 
 let jobsDone = 0
 
-const token = core.getInput('github-token', {required: true})
-const hydratedOctokit = new Octokit({
-  auth: token
-})
+type PullsListResponseDataType = Endpoints["GET /repos/{owner}/{repo}/pulls"]["response"]["data"]
 
-type PullsListResponseType = types.GetResponseDataTypeFromEndpointMethod<
-  typeof hydratedOctokit.pulls.list
->
-
-type PullsListResponseItem = PullsListResponseType extends (infer Item)[]
+type PullsListResponseItem = PullsListResponseDataType extends (infer Item)[]
   ? Item
   : never
 
@@ -35,10 +27,15 @@ export const cronLgtm = async (
 ): Promise<number> => {
   core.info(`starting lgtm merger page: ${currentPage}`)
 
+  const token = core.getInput('github-token', { required: true })
+  const octokit = new Octokit({
+    auth: token
+  })
+
   // Get next batch
-  let prs: PullsListResponseType
+  let prs: PullsListResponseDataType
   try {
-    prs = await getOpenPrs(hydratedOctokit, context, currentPage)
+    prs = await getOpenPrs(octokit, context, currentPage)
   } catch (e) {
     throw new Error(`could not get PRs: ${e}`)
   }
@@ -60,7 +57,7 @@ export const cronLgtm = async (
       }
 
       try {
-        await tryMergePr(pr, hydratedOctokit, context)
+        await tryMergePr(pr, octokit, context)
         jobsDone++
       } catch (error) {
         return error
@@ -89,7 +86,7 @@ const getOpenPrs = async (
   octokit: Octokit,
   context: Context = github.context,
   page: number
-): Promise<PullsListResponseType> => {
+): Promise<PullsListResponseDataType> => {
   core.debug(`getting prs page ${page}...`)
 
   const prResults = await octokit.pulls.list({
@@ -115,38 +112,44 @@ const tryMergePr = async (
   octokit: Octokit,
   context: Context = github.context
 ): Promise<void> => {
-  const method = core.getInput('merge-method', {required: false})
+  const method = core.getInput('merge-method', { required: false })
 
   // if pr has label 'lgtm', attempt to merge
   // but not if it has the 'hold' label
   if (
-    pr.labels.map(e => e.name).includes('lgtm') &&
-    !pr.labels.map(e => e.name).includes('hold')
+    pr.labels.map((e) => e.name).includes('lgtm') &&
+    !pr.labels.map((e) => e.name).includes('hold')
   ) {
     try {
       switch (method) {
         case 'squash':
+          /* eslint-disable @typescript-eslint/naming-convention */
           await octokit.pulls.merge({
             ...context.repo,
             pull_number: pr.number,
             merge_method: 'squash'
           })
+          /* eslint-enable @typescript-eslint/naming-convention */
           break
 
         case 'rebase':
+          /* eslint-disable @typescript-eslint/naming-convention */
           await octokit.pulls.merge({
             ...context.repo,
             pull_number: pr.number,
             merge_method: 'rebase'
           })
+          /* eslint-enable @typescript-eslint/naming-convention */
           break
 
         default:
+          /* eslint-disable @typescript-eslint/naming-convention */
           await octokit.pulls.merge({
             ...context.repo,
             pull_number: pr.number,
             merge_method: 'merge'
           })
+        /* eslint-enable @typescript-eslint/naming-convention */
       }
     } catch (e) {
       core.debug(`could not merge pr ${pr.number}: ${e}`)

--- a/src/cronJobs/lgtm.ts
+++ b/src/cronJobs/lgtm.ts
@@ -1,13 +1,14 @@
 import * as github from '@actions/github'
-import { Octokit } from '@octokit/rest'
-import { Endpoints } from '@octokit/types'
+import {Octokit} from '@octokit/rest'
+import {Endpoints} from '@octokit/types'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 import * as core from '@actions/core'
 
 let jobsDone = 0
 
-type PullsListResponseDataType = Endpoints["GET /repos/{owner}/{repo}/pulls"]["response"]["data"]
+type PullsListResponseDataType =
+  Endpoints['GET /repos/{owner}/{repo}/pulls']['response']['data']
 
 type PullsListResponseItem = PullsListResponseDataType extends (infer Item)[]
   ? Item
@@ -27,7 +28,7 @@ export const cronLgtm = async (
 ): Promise<number> => {
   core.info(`starting lgtm merger page: ${currentPage}`)
 
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })
@@ -112,13 +113,13 @@ const tryMergePr = async (
   octokit: Octokit,
   context: Context = github.context
 ): Promise<void> => {
-  const method = core.getInput('merge-method', { required: false })
+  const method = core.getInput('merge-method', {required: false})
 
   // if pr has label 'lgtm', attempt to merge
   // but not if it has the 'hold' label
   if (
-    pr.labels.map((e) => e.name).includes('lgtm') &&
-    !pr.labels.map((e) => e.name).includes('hold')
+    pr.labels.map(e => e.name).includes('lgtm') &&
+    !pr.labels.map(e => e.name).includes('hold')
   ) {
     try {
       switch (method) {

--- a/src/cronJobs/prLabeler.ts
+++ b/src/cronJobs/prLabeler.ts
@@ -1,9 +1,9 @@
 import * as github from '@actions/github'
-import {Octokit} from '@octokit/rest'
+import { Octokit } from '@octokit/rest'
 
-import {Context} from '@actions/github/lib/context'
+import { Context } from '@actions/github/lib/context'
 import * as core from '@actions/core'
-import * as types from '@octokit/types'
+import { Endpoints } from '@octokit/types'
 
 import * as yaml from 'js-yaml'
 import * as minimatch from 'minimatch'
@@ -12,15 +12,7 @@ import * as minimatch from 'minimatch'
 // while recursing through pages of the github api
 let jobsDone = 0
 
-const token = core.getInput('github-token', {required: true})
-const hydratedOctokit = new Octokit({
-  auth: token
-})
-
-// TODO: Abstract out types?
-type PullsListResponseType = types.GetResponseDataTypeFromEndpointMethod<
-  typeof hydratedOctokit.pulls.list
->
+type PullsListResponseDataType = Endpoints["GET /repos/{owner}/{repo}/pulls"]["response"]["data"]
 
 /**
  * Inspired by https://github.com/actions/stale
@@ -36,13 +28,13 @@ export const cronLabelPr = async (
 ): Promise<number> => {
   core.info(`starting PR labeler page ${currentPage}`)
 
-  const token = core.getInput('github-token', {required: true})
+  const token = core.getInput('github-token', { required: true })
   const octokit = new Octokit({
     auth: token
   })
 
   // Get next batch
-  let prs: PullsListResponseType
+  let prs: PullsListResponseDataType
   try {
     prs = await getPrs(octokit, context, currentPage)
   } catch (e) {
@@ -85,7 +77,7 @@ const getPrs = async (
   octokit: Octokit,
   context: Context = github.context,
   page: number
-): Promise<PullsListResponseType> => {
+): Promise<PullsListResponseDataType> => {
   core.debug(`getting prs page ${page}...`)
   const prResults = await octokit.pulls.list({
     ...context.repo,
@@ -134,10 +126,12 @@ const getChangedFiles = async (
   prNum: number
 ): Promise<string[]> => {
   core.debug(`getting changed files for pr ${prNum}`)
+  /* eslint-disable @typescript-eslint/naming-convention */
   const listFilesResponse = await octokit.pulls.listFiles({
     ...context.repo,
     pull_number: prNum
   })
+  /* eslint-enable @typescript-eslint/naming-convention */
 
   const changedFiles = listFilesResponse.data.map(f => f.filename)
   core.debug(`files changed: ${changedFiles}`)
@@ -193,6 +187,7 @@ const getLabelsFromFileGlobs = async (
   ).toString()
 
   core.debug(`label file contents: ${decoded}`)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const content: any = yaml.load(decoded)
 
   const labelMap: Map<string, string[]> = new Map()
@@ -255,11 +250,13 @@ export const sendLabels = async (
 ): Promise<void> => {
   try {
     core.debug(`sending labels ${labels} for PR ${prNum}`)
+    /* eslint-disable @typescript-eslint/naming-convention */
     await octokit.issues.addLabels({
       ...context.repo,
       issue_number: prNum,
       labels
     })
+    /* eslint-enable @typescript-eslint/naming-convention */
   } catch (e) {
     throw new Error(`sending labels: ${e}`)
   }

--- a/src/cronJobs/prLabeler.ts
+++ b/src/cronJobs/prLabeler.ts
@@ -1,9 +1,9 @@
 import * as github from '@actions/github'
-import { Octokit } from '@octokit/rest'
+import {Octokit} from '@octokit/rest'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 import * as core from '@actions/core'
-import { Endpoints } from '@octokit/types'
+import {Endpoints} from '@octokit/types'
 
 import * as yaml from 'js-yaml'
 import * as minimatch from 'minimatch'
@@ -12,7 +12,8 @@ import * as minimatch from 'minimatch'
 // while recursing through pages of the github api
 let jobsDone = 0
 
-type PullsListResponseDataType = Endpoints["GET /repos/{owner}/{repo}/pulls"]["response"]["data"]
+type PullsListResponseDataType =
+  Endpoints['GET /repos/{owner}/{repo}/pulls']['response']['data']
 
 /**
  * Inspired by https://github.com/actions/stale
@@ -28,7 +29,7 @@ export const cronLabelPr = async (
 ): Promise<number> => {
   core.info(`starting PR labeler page ${currentPage}`)
 
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })

--- a/src/issueComment/approve.ts
+++ b/src/issueComment/approve.ts
@@ -1,14 +1,15 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
-import { Endpoints } from '@octokit/types'
+import {Endpoints} from '@octokit/types'
 
-import { Octokit } from '@octokit/rest'
-import { Context } from '@actions/github/lib/context'
-import { getCommandArgs } from '../utils/command'
-import { assertAuthorizedByOwnersOrMembership } from '../utils/auth'
-import { createComment } from '../utils/comments'
+import {Octokit} from '@octokit/rest'
+import {Context} from '@actions/github/lib/context'
+import {getCommandArgs} from '../utils/command'
+import {assertAuthorizedByOwnersOrMembership} from '../utils/auth'
+import {createComment} from '../utils/comments'
 
-type PullsListReviewsResponseType = Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews"]["response"]
+type PullsListReviewsResponseType =
+  Endpoints['GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews']['response']
 
 /**
  * the /approve command will create a "approve" review
@@ -23,7 +24,7 @@ export const approve = async (
   context: Context = github.context
 ): Promise<void> => {
   core.debug(`starting approve job`)
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })

--- a/src/issueComment/approve.ts
+++ b/src/issueComment/approve.ts
@@ -1,11 +1,14 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
+import { Endpoints } from '@octokit/types'
 
-import {Octokit} from '@octokit/rest'
-import {Context} from '@actions/github/lib/context'
-import {getCommandArgs} from '../utils/command'
-import {assertAuthorizedByOwnersOrMembership} from '../utils/auth'
-import {createComment} from '../utils/comments'
+import { Octokit } from '@octokit/rest'
+import { Context } from '@actions/github/lib/context'
+import { getCommandArgs } from '../utils/command'
+import { assertAuthorizedByOwnersOrMembership } from '../utils/auth'
+import { createComment } from '../utils/comments'
+
+type PullsListReviewsResponseType = Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews"]["response"]
 
 /**
  * the /approve command will create a "approve" review
@@ -20,8 +23,7 @@ export const approve = async (
   context: Context = github.context
 ): Promise<void> => {
   core.debug(`starting approve job`)
-
-  const token = core.getInput('github-token', {required: true})
+  const token = core.getInput('github-token', { required: true })
   const octokit = new Octokit({
     auth: token
   })
@@ -71,12 +73,14 @@ export const approve = async (
 
   try {
     core.debug(`creating a review`)
+    /* eslint-disable @typescript-eslint/naming-convention */
     await octokit.pulls.createReview({
       ...context.repo,
       pull_number: issueNumber,
       event: 'APPROVE',
       comments: []
     })
+    /* eslint-enable @typescript-eslint/naming-convention */
   } catch (e) {
     throw new Error(`could not create review: ${e}`)
   }
@@ -98,20 +102,23 @@ const cancel = async (
 ): Promise<void> => {
   core.debug(`canceling latest review`)
 
-  let reviews: Octokit.Response<Octokit.PullsListReviewsResponse>
+  let reviews: PullsListReviewsResponseType
   try {
+    /* eslint-disable @typescript-eslint/naming-convention */
     reviews = await octokit.pulls.listReviews({
       ...context.repo,
       pull_number: issueNumber
     })
+    /* eslint-enable @typescript-eslint/naming-convention */
   } catch (e) {
     throw new Error(`could not list reviews for PR ${issueNumber}: ${e}`)
   }
 
   let latestReview = undefined
+
   for (const e of reviews.data) {
-    core.debug(`checking review: ${e.user.login}`)
-    if (e.user.login === 'github-actions[bot]' && e.state === 'APPROVED') {
+    core.debug(`checking review: ${e.user?.login}`)
+    if (e.user?.login === 'github-actions[bot]' && e.state === 'APPROVED') {
       latestReview = e
     }
   }
@@ -121,12 +128,14 @@ const cancel = async (
   }
 
   try {
+    /* eslint-disable @typescript-eslint/naming-convention */
     await octokit.pulls.dismissReview({
       ...context.repo,
       pull_number: issueNumber,
       review_id: latestReview.id,
       message: `Canceled through prow-github-actions by @${commenterLogin}`
     })
+    /* eslint-enable @typescript-eslint/naming-convention */
   } catch (e) {
     throw new Error(`could not dismiss review: ${e}`)
   }

--- a/src/issueComment/assign.ts
+++ b/src/issueComment/assign.ts
@@ -1,12 +1,12 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
 
-import { Octokit } from '@octokit/rest'
+import {Octokit} from '@octokit/rest'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 
-import { getCommandArgs } from '../utils/command'
-import { getOrgCollabCommentUsers, checkCommenterAuth } from '../utils/auth'
+import {getCommandArgs} from '../utils/command'
+import {getOrgCollabCommentUsers, checkCommenterAuth} from '../utils/auth'
 
 /**
  * /assign will self assign with no argument
@@ -19,7 +19,7 @@ export const assign = async (
 ): Promise<void> => {
   core.debug(`starting assign job`)
 
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })

--- a/src/issueComment/assign.ts
+++ b/src/issueComment/assign.ts
@@ -1,10 +1,12 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
 
-import {Context} from '@actions/github/lib/context'
+import { Octokit } from '@octokit/rest'
 
-import {getCommandArgs} from '../utils/command'
-import {getOrgCollabCommentUsers, checkCommenterAuth} from '../utils/auth'
+import { Context } from '@actions/github/lib/context'
+
+import { getCommandArgs } from '../utils/command'
+import { getOrgCollabCommentUsers, checkCommenterAuth } from '../utils/auth'
 
 /**
  * /assign will self assign with no argument
@@ -17,12 +19,14 @@ export const assign = async (
 ): Promise<void> => {
   core.debug(`starting assign job`)
 
-  const token = core.getInput('github-token', {required: true})
-  const octokit = new github.GitHub(token)
+  const token = core.getInput('github-token', { required: true })
+  const octokit = new Octokit({
+    auth: token
+  })
 
   const issueNumber: number | undefined = context.payload.issue?.number
-  const commenterId: string = context.payload['comment']['user']['login']
-  const commentBody: string = context.payload['comment']['body']
+  const commenterId: string = context.payload.comment?.user?.login
+  const commentBody: string = context.payload.comment?.body
 
   if (issueNumber === undefined) {
     throw new Error(
@@ -66,11 +70,13 @@ export const assign = async (
 
     default:
       try {
+        /* eslint-disable @typescript-eslint/naming-convention */
         await octokit.issues.addAssignees({
           ...context.repo,
           issue_number: issueNumber,
           assignees: authUsers
         })
+        /* eslint-enable @typescript-eslint/naming-convention */
       } catch (e) {
         throw new Error(`could not add assignees: ${e}`)
       }
@@ -87,7 +93,7 @@ export const assign = async (
  * @param user - the user to self assign
  */
 const selfAssign = async (
-  octokit: github.GitHub,
+  octokit: Octokit,
   context: Context,
   issueNum: number,
   user: string
@@ -100,10 +106,12 @@ const selfAssign = async (
   )
 
   if (isAuthorized) {
+    /* eslint-disable @typescript-eslint/naming-convention */
     await octokit.issues.addAssignees({
       ...context.repo,
       issue_number: issueNum,
       assignees: [user]
     })
+    /* eslint-enable @typescript-eslint/naming-convention */
   }
 }

--- a/src/issueComment/cc.ts
+++ b/src/issueComment/cc.ts
@@ -1,10 +1,11 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
+import { Octokit } from '@octokit/rest'
 
-import {Context} from '@actions/github/lib/context'
+import { Context } from '@actions/github/lib/context'
 
-import {getCommandArgs} from '../utils/command'
-import {checkCollaborator, getOrgCollabCommentUsers} from '../utils/auth'
+import { getCommandArgs } from '../utils/command'
+import { checkCollaborator, getOrgCollabCommentUsers } from '../utils/auth'
 
 /**
  * /cc will request a review from self with no arguments or the users specified
@@ -13,12 +14,14 @@ import {checkCollaborator, getOrgCollabCommentUsers} from '../utils/auth'
  * @param context - the github actions event context
  */
 export const cc = async (context: Context = github.context): Promise<void> => {
-  const token = core.getInput('github-token', {required: true})
-  const octokit = new github.GitHub(token)
+  const token = core.getInput('github-token', { required: true })
+  const octokit = new Octokit({
+    auth: token
+  })
 
   const pullNumber: number | undefined = context.payload.issue?.number
-  const commenterId: string = context.payload['comment']['user']['login']
-  const commentBody: string = context.payload['comment']['body']
+  const commenterId: string = context.payload.comment?.user?.login
+  const commentBody: string = context.payload.comment?.body
 
   if (pullNumber === undefined) {
     throw new Error(
@@ -62,11 +65,13 @@ export const cc = async (context: Context = github.context): Promise<void> => {
 
     default:
       try {
-        await octokit.pulls.createReviewRequest({
+        /* eslint-disable @typescript-eslint/naming-convention */
+        await octokit.pulls.requestReviewers({
           ...context.repo,
           pull_number: pullNumber,
           reviewers: authUsers
         })
+        /* eslint-enable @typescript-eslint/naming-convention */
       } catch (e) {
         throw new Error(`could not request reviewers: ${e}`)
       }
@@ -83,7 +88,7 @@ export const cc = async (context: Context = github.context): Promise<void> => {
  * @param user - the user to request a self review
  */
 const selfReview = async (
-  octokit: github.GitHub,
+  octokit: Octokit,
   context: Context,
   pullNum: number,
   user: string
@@ -91,10 +96,12 @@ const selfReview = async (
   const isCollaborator = await checkCollaborator(octokit, context, user)
 
   if (isCollaborator) {
-    await octokit.pulls.createReviewRequest({
+    /* eslint-disable @typescript-eslint/naming-convention */
+    await octokit.pulls.requestReviewers({
       ...context.repo,
       pull_number: pullNum,
       reviewers: [user]
     })
+    /* eslint-enable @typescript-eslint/naming-convention */
   }
 }

--- a/src/issueComment/cc.ts
+++ b/src/issueComment/cc.ts
@@ -1,11 +1,11 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
-import { Octokit } from '@octokit/rest'
+import {Octokit} from '@octokit/rest'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 
-import { getCommandArgs } from '../utils/command'
-import { checkCollaborator, getOrgCollabCommentUsers } from '../utils/auth'
+import {getCommandArgs} from '../utils/command'
+import {checkCollaborator, getOrgCollabCommentUsers} from '../utils/auth'
 
 /**
  * /cc will request a review from self with no arguments or the users specified
@@ -14,7 +14,7 @@ import { checkCollaborator, getOrgCollabCommentUsers } from '../utils/auth'
  * @param context - the github actions event context
  */
 export const cc = async (context: Context = github.context): Promise<void> => {
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })

--- a/src/issueComment/close.ts
+++ b/src/issueComment/close.ts
@@ -1,9 +1,10 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
+import { Octokit } from '@octokit/rest'
 
-import {Context} from '@actions/github/lib/context'
+import { Context } from '@actions/github/lib/context'
 
-import {checkCollaborator} from '../utils/auth'
+import { checkCollaborator } from '../utils/auth'
 
 /**
  * /close will close the issue / PR
@@ -13,11 +14,13 @@ import {checkCollaborator} from '../utils/auth'
 export const close = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', {required: true})
-  const octokit = new github.GitHub(token)
+  const token = core.getInput('github-token', { required: true })
+  const octokit = new Octokit({
+    auth: token
+  })
 
   const issueNumber: number | undefined = context.payload.issue?.number
-  const commenterId: string = context.payload['comment']['user']['login']
+  const commenterId: string = context.payload.comment?.user?.login
 
   if (issueNumber === undefined) {
     throw new Error(
@@ -36,11 +39,13 @@ export const close = async (
 
   if (isAuthUser) {
     try {
+      /* eslint-disable @typescript-eslint/naming-convention */
       await octokit.issues.update({
         ...context.repo,
         issue_number: issueNumber,
         state: 'closed'
       })
+      /* eslint-enable @typescript-eslint/naming-convention */
     } catch (e) {
       throw new Error(`could not close issue: ${e}`)
     }

--- a/src/issueComment/close.ts
+++ b/src/issueComment/close.ts
@@ -1,10 +1,10 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
-import { Octokit } from '@octokit/rest'
+import {Octokit} from '@octokit/rest'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 
-import { checkCollaborator } from '../utils/auth'
+import {checkCollaborator} from '../utils/auth'
 
 /**
  * /close will close the issue / PR
@@ -14,7 +14,7 @@ import { checkCollaborator } from '../utils/auth'
 export const close = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })

--- a/src/issueComment/handleIssueComment.ts
+++ b/src/issueComment/handleIssueComment.ts
@@ -1,24 +1,24 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 
-import {Context} from '@actions/github/lib/context'
+import { Context } from '@actions/github/lib/context'
 
-import {assign} from './assign'
-import {unassign} from './unassign'
-import {approve} from './approve'
-import {retitle} from './retitle'
-import {remove} from '../labels/remove'
-import {area} from '../labels/area'
-import {kind} from '../labels/kind'
-import {priority} from '../labels/priority'
-import {lgtm} from '../labels/lgtm'
-import {hold} from '../labels/hold'
-import {close} from './close'
-import {reopen} from './reopen'
-import {lock} from './lock'
-import {cc} from './cc'
-import {uncc} from './uncc'
-import {milestone} from './milestone'
+import { assign } from './assign'
+import { unassign } from './unassign'
+import { approve } from './approve'
+import { retitle } from './retitle'
+import { remove } from '../labels/remove'
+import { area } from '../labels/area'
+import { kind } from '../labels/kind'
+import { priority } from '../labels/priority'
+import { lgtm } from '../labels/lgtm'
+import { hold } from '../labels/hold'
+import { close } from './close'
+import { reopen } from './reopen'
+import { lock } from './lock'
+import { cc } from './cc'
+import { uncc } from './uncc'
+import { milestone } from './milestone'
 
 /**
  * This Method handles any issue comments
@@ -31,10 +31,10 @@ export const handleIssueComment = async (
   context: Context = github.context
 ): Promise<void> => {
   const commandConfig = core
-    .getInput('prow-commands', {required: false})
+    .getInput('prow-commands', { required: false })
     .replace(/\n/g, ' ')
     .split(' ')
-  const commentBody: string = context.payload['comment']['body']
+  const commentBody: string = context.payload.comment?.body
 
   await Promise.all(
     commandConfig.map(async command => {

--- a/src/issueComment/handleIssueComment.ts
+++ b/src/issueComment/handleIssueComment.ts
@@ -1,24 +1,24 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 
-import { assign } from './assign'
-import { unassign } from './unassign'
-import { approve } from './approve'
-import { retitle } from './retitle'
-import { remove } from '../labels/remove'
-import { area } from '../labels/area'
-import { kind } from '../labels/kind'
-import { priority } from '../labels/priority'
-import { lgtm } from '../labels/lgtm'
-import { hold } from '../labels/hold'
-import { close } from './close'
-import { reopen } from './reopen'
-import { lock } from './lock'
-import { cc } from './cc'
-import { uncc } from './uncc'
-import { milestone } from './milestone'
+import {assign} from './assign'
+import {unassign} from './unassign'
+import {approve} from './approve'
+import {retitle} from './retitle'
+import {remove} from '../labels/remove'
+import {area} from '../labels/area'
+import {kind} from '../labels/kind'
+import {priority} from '../labels/priority'
+import {lgtm} from '../labels/lgtm'
+import {hold} from '../labels/hold'
+import {close} from './close'
+import {reopen} from './reopen'
+import {lock} from './lock'
+import {cc} from './cc'
+import {uncc} from './uncc'
+import {milestone} from './milestone'
 
 /**
  * This Method handles any issue comments
@@ -31,7 +31,7 @@ export const handleIssueComment = async (
   context: Context = github.context
 ): Promise<void> => {
   const commandConfig = core
-    .getInput('prow-commands', { required: false })
+    .getInput('prow-commands', {required: false})
     .replace(/\n/g, ' ')
     .split(' ')
   const commentBody: string = context.payload.comment?.body

--- a/src/issueComment/lock.ts
+++ b/src/issueComment/lock.ts
@@ -1,11 +1,11 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
-import { Octokit } from '@octokit/rest'
+import {Octokit} from '@octokit/rest'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 
-import { checkCollaborator } from '../utils/auth'
-import { getCommandArgs } from '../utils/command'
+import {checkCollaborator} from '../utils/auth'
+import {getCommandArgs} from '../utils/command'
 
 /**
  * /lock will lock the issue / PR.
@@ -16,7 +16,7 @@ import { getCommandArgs } from '../utils/command'
 export const lock = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })

--- a/src/issueComment/lock.ts
+++ b/src/issueComment/lock.ts
@@ -1,10 +1,11 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
+import { Octokit } from '@octokit/rest'
 
-import {Context} from '@actions/github/lib/context'
+import { Context } from '@actions/github/lib/context'
 
-import {checkCollaborator} from '../utils/auth'
-import {getCommandArgs} from '../utils/command'
+import { checkCollaborator } from '../utils/auth'
+import { getCommandArgs } from '../utils/command'
 
 /**
  * /lock will lock the issue / PR.
@@ -15,12 +16,14 @@ import {getCommandArgs} from '../utils/command'
 export const lock = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', {required: true})
-  const octokit = new github.GitHub(token)
+  const token = core.getInput('github-token', { required: true })
+  const octokit = new Octokit({
+    auth: token
+  })
 
   const issueNumber: number | undefined = context.payload.issue?.number
-  const commenterId: string = context.payload['comment']['user']['login']
-  const commentBody: string = context.payload['comment']['body']
+  const commenterId: string = context.payload.comment?.user?.login
+  const commentBody: string = context.payload.comment?.body
 
   if (issueNumber === undefined) {
     throw new Error(
@@ -44,10 +47,12 @@ export const lock = async (
       switch (commentArgs[0]) {
         case 'resolved':
           try {
+            /* eslint-disable @typescript-eslint/naming-convention */
             await octokit.issues.lock({
               ...context.repo,
               issue_number: issueNumber
             })
+            /* eslint-enable @typescript-eslint/naming-convention */
           } catch (e) {
             throw new Error(`could not lock issue: ${e}`)
           }
@@ -55,11 +60,13 @@ export const lock = async (
 
         case 'off-topic':
           try {
+            /* eslint-disable @typescript-eslint/naming-convention */
             await octokit.issues.lock({
               ...context.repo,
               issue_number: issueNumber,
               lock_reason: 'off-topic'
             })
+            /* eslint-enable @typescript-eslint/naming-convention */
           } catch (e) {
             throw new Error(`could not lock issue: ${e}`)
           }
@@ -67,11 +74,13 @@ export const lock = async (
 
         case 'too-heated':
           try {
+            /* eslint-disable @typescript-eslint/naming-convention */
             await octokit.issues.lock({
               ...context.repo,
               issue_number: issueNumber,
               lock_reason: 'too heated'
             })
+            /* eslint-enable @typescript-eslint/naming-convention */
           } catch (e) {
             throw new Error(`could not lock issue: ${e}`)
           }
@@ -79,11 +88,13 @@ export const lock = async (
 
         case 'spam':
           try {
+            /* eslint-disable @typescript-eslint/naming-convention */
             await octokit.issues.lock({
               ...context.repo,
               issue_number: issueNumber,
               lock_reason: 'spam'
             })
+            /* eslint-enable @typescript-eslint/naming-convention */
           } catch (e) {
             throw new Error(`could not lock issue: ${e}`)
           }
@@ -91,10 +102,12 @@ export const lock = async (
 
         default:
           try {
+            /* eslint-disable @typescript-eslint/naming-convention */
             await octokit.issues.lock({
               ...context.repo,
               issue_number: issueNumber
             })
+            /* eslint-enable @typescript-eslint/naming-convention */
           } catch (e) {
             throw new Error(`could not lock issue: ${e}`)
           }
@@ -102,10 +115,12 @@ export const lock = async (
       }
     } else {
       try {
+        /* eslint-disable @typescript-eslint/naming-convention */
         await octokit.issues.lock({
           ...context.repo,
           issue_number: issueNumber
         })
+        /* eslint-enable @typescript-eslint/naming-convention */
       } catch (e) {
         throw new Error(`could not lock issue: ${e}`)
       }

--- a/src/issueComment/milestone.ts
+++ b/src/issueComment/milestone.ts
@@ -1,12 +1,12 @@
 import * as github from '@actions/github'
-import { Octokit } from '@octokit/rest'
+import {Octokit} from '@octokit/rest'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 
 import * as core from '@actions/core'
 
-import { getLineArgs } from '../utils/command'
-import { checkCollaborator } from '../utils/auth'
+import {getLineArgs} from '../utils/command'
+import {checkCollaborator} from '../utils/auth'
 
 /**
  * /milestone will add the issue to an existing milestone.
@@ -17,7 +17,7 @@ import { checkCollaborator } from '../utils/auth'
 export const milestone = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })

--- a/src/issueComment/reopen.ts
+++ b/src/issueComment/reopen.ts
@@ -1,10 +1,10 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
-import { Octokit } from '@octokit/rest'
+import {Octokit} from '@octokit/rest'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 
-import { checkCollaborator } from '../utils/auth'
+import {checkCollaborator} from '../utils/auth'
 
 /**
  * /reopen will reopen the issue / PR. May be called after /close
@@ -14,7 +14,7 @@ import { checkCollaborator } from '../utils/auth'
 export const reopen = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })

--- a/src/issueComment/reopen.ts
+++ b/src/issueComment/reopen.ts
@@ -1,9 +1,10 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
+import { Octokit } from '@octokit/rest'
 
-import {Context} from '@actions/github/lib/context'
+import { Context } from '@actions/github/lib/context'
 
-import {checkCollaborator} from '../utils/auth'
+import { checkCollaborator } from '../utils/auth'
 
 /**
  * /reopen will reopen the issue / PR. May be called after /close
@@ -13,11 +14,13 @@ import {checkCollaborator} from '../utils/auth'
 export const reopen = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', {required: true})
-  const octokit = new github.GitHub(token)
+  const token = core.getInput('github-token', { required: true })
+  const octokit = new Octokit({
+    auth: token
+  })
 
   const issueNumber: number | undefined = context.payload.issue?.number
-  const commenterId: string = context.payload['comment']['user']['login']
+  const commenterId: string = context.payload.comment?.user?.login
 
   if (issueNumber === undefined) {
     throw new Error(
@@ -36,11 +39,13 @@ export const reopen = async (
 
   if (isAuthUser) {
     try {
+      /* eslint-disable @typescript-eslint/naming-convention */
       await octokit.issues.update({
         ...context.repo,
         issue_number: issueNumber,
         state: 'open'
       })
+      /* eslint-enable @typescript-eslint/naming-convention */
     } catch (e) {
       throw new Error(`could not open issue: ${e}`)
     }

--- a/src/issueComment/retitle.ts
+++ b/src/issueComment/retitle.ts
@@ -1,11 +1,11 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
-import { Octokit } from '@octokit/rest'
+import {Octokit} from '@octokit/rest'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 
-import { getCommandArgs } from '../utils/command'
-import { checkCollaborator } from '../utils/auth'
+import {getCommandArgs} from '../utils/command'
+import {checkCollaborator} from '../utils/auth'
 
 /**
  * /retitle will "rename" the issue / PR.
@@ -16,7 +16,7 @@ import { checkCollaborator } from '../utils/auth'
 export const retitle = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })

--- a/src/issueComment/retitle.ts
+++ b/src/issueComment/retitle.ts
@@ -1,10 +1,11 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
+import { Octokit } from '@octokit/rest'
 
-import {Context} from '@actions/github/lib/context'
+import { Context } from '@actions/github/lib/context'
 
-import {getCommandArgs} from '../utils/command'
-import {checkCollaborator} from '../utils/auth'
+import { getCommandArgs } from '../utils/command'
+import { checkCollaborator } from '../utils/auth'
 
 /**
  * /retitle will "rename" the issue / PR.
@@ -15,12 +16,14 @@ import {checkCollaborator} from '../utils/auth'
 export const retitle = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', {required: true})
-  const octokit = new github.GitHub(token)
+  const token = core.getInput('github-token', { required: true })
+  const octokit = new Octokit({
+    auth: token
+  })
 
   const issueNumber: number | undefined = context.payload.issue?.number
-  const commenterId: string = context.payload['comment']['user']['login']
-  const commentBody: string = context.payload['comment']['body']
+  const commenterId: string = context.payload.comment?.user?.login
+  const commentBody: string = context.payload.comment?.body
 
   if (issueNumber === undefined) {
     throw new Error(
@@ -46,11 +49,13 @@ export const retitle = async (
 
   if (isAuthUser) {
     try {
+      /* eslint-disable @typescript-eslint/naming-convention */
       await octokit.issues.update({
         ...context.repo,
         issue_number: issueNumber,
         title: commentArgs.join(' ')
       })
+      /* eslint-enable @typescript-eslint/naming-convention */
     } catch (e) {
       throw new Error(`could not update issue: ${e}`)
     }

--- a/src/issueComment/unassign.ts
+++ b/src/issueComment/unassign.ts
@@ -1,10 +1,11 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
+import { Octokit } from '@octokit/rest'
 
-import {Context} from '@actions/github/lib/context'
+import { Context } from '@actions/github/lib/context'
 
-import {getCommandArgs} from '../utils/command'
-import {checkCommenterAuth} from '../utils/auth'
+import { getCommandArgs } from '../utils/command'
+import { checkCommenterAuth } from '../utils/auth'
 
 /**
  * /unassign will remove the assignment for argument users (or self)
@@ -14,12 +15,14 @@ import {checkCommenterAuth} from '../utils/auth'
 export const unassign = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', {required: true})
-  const octokit = new github.GitHub(token)
+  const token = core.getInput('github-token', { required: true })
+  const octokit = new Octokit({
+    auth: token
+  })
 
   const issueNumber: number | undefined = context.payload.issue?.number
-  const commenterId: string = context.payload['comment']['user']['login']
-  const commentBody: string = context.payload['comment']['body']
+  const commenterId: string = context.payload.comment?.user?.login
+  const commentBody: string = context.payload.comment?.body
 
   if (issueNumber === undefined) {
     throw new Error(
@@ -32,11 +35,13 @@ export const unassign = async (
   // no arguments after command provided
   if (commentArgs.length === 0) {
     try {
+      /* eslint-disable @typescript-eslint/naming-convention */
       await octokit.issues.removeAssignees({
         ...context.repo,
         issue_number: issueNumber,
         assignees: [commenterId]
       })
+      /* eslint-enable @typescript-eslint/naming-convention */
     } catch (e) {
       throw new Error(`could not remove assignee: ${e}`)
     }
@@ -58,11 +63,13 @@ export const unassign = async (
 
   if (isAuthUser) {
     try {
+      /* eslint-disable @typescript-eslint/naming-convention */
       await octokit.issues.removeAssignees({
         ...context.repo,
         issue_number: issueNumber,
         assignees: commentArgs
       })
+      /* eslint-enable @typescript-eslint/naming-convention */
     } catch (e) {
       throw new Error(`could not remove assignee: ${e}`)
     }

--- a/src/issueComment/unassign.ts
+++ b/src/issueComment/unassign.ts
@@ -1,11 +1,11 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
-import { Octokit } from '@octokit/rest'
+import {Octokit} from '@octokit/rest'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 
-import { getCommandArgs } from '../utils/command'
-import { checkCommenterAuth } from '../utils/auth'
+import {getCommandArgs} from '../utils/command'
+import {checkCommenterAuth} from '../utils/auth'
 
 /**
  * /unassign will remove the assignment for argument users (or self)
@@ -15,7 +15,7 @@ import { checkCommenterAuth } from '../utils/auth'
 export const unassign = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })

--- a/src/issueComment/uncc.ts
+++ b/src/issueComment/uncc.ts
@@ -1,11 +1,11 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
-import { Octokit } from '@octokit/rest'
+import {Octokit} from '@octokit/rest'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 
-import { getCommandArgs } from '../utils/command'
-import { checkCollaborator, checkCommenterAuth } from '../utils/auth'
+import {getCommandArgs} from '../utils/command'
+import {checkCollaborator, checkCommenterAuth} from '../utils/auth'
 
 /**
  * /uncc will remove the review request for argument users (or self)
@@ -15,7 +15,7 @@ import { checkCollaborator, checkCommenterAuth } from '../utils/auth'
 export const uncc = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })

--- a/src/labels/area.ts
+++ b/src/labels/area.ts
@@ -1,10 +1,11 @@
 import * as github from '@actions/github'
+import { Octokit } from '@octokit/rest'
 
-import {Context} from '@actions/github/lib/context'
+import { Context } from '@actions/github/lib/context'
 import * as core from '@actions/core'
 
-import {getCommandArgs} from '../utils/command'
-import {getArgumentLabels, labelIssue, addPrefix} from '../utils/labeling'
+import { getCommandArgs } from '../utils/command'
+import { getArgumentLabels, labelIssue, addPrefix } from '../utils/labeling'
 
 /**
  * /area will add an area/some-area label
@@ -14,11 +15,13 @@ import {getArgumentLabels, labelIssue, addPrefix} from '../utils/labeling'
 export const area = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', {required: true})
-  const octokit = new github.GitHub(token)
+  const token = core.getInput('github-token', { required: true })
+  const octokit = new Octokit({
+    auth: token
+  })
 
   const issueNumber: number | undefined = context.payload.issue?.number
-  const commentBody: string = context.payload['comment']['body']
+  const commentBody: string = context.payload.comment?.body
 
   if (issueNumber === undefined) {
     throw new Error(

--- a/src/labels/area.ts
+++ b/src/labels/area.ts
@@ -1,11 +1,11 @@
 import * as github from '@actions/github'
-import { Octokit } from '@octokit/rest'
+import {Octokit} from '@octokit/rest'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 import * as core from '@actions/core'
 
-import { getCommandArgs } from '../utils/command'
-import { getArgumentLabels, labelIssue, addPrefix } from '../utils/labeling'
+import {getCommandArgs} from '../utils/command'
+import {getArgumentLabels, labelIssue, addPrefix} from '../utils/labeling'
 
 /**
  * /area will add an area/some-area label
@@ -15,7 +15,7 @@ import { getArgumentLabels, labelIssue, addPrefix } from '../utils/labeling'
 export const area = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })

--- a/src/labels/hold.ts
+++ b/src/labels/hold.ts
@@ -1,11 +1,11 @@
 import * as github from '@actions/github'
-import { Octokit } from '@octokit/rest'
+import {Octokit} from '@octokit/rest'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 import * as core from '@actions/core'
 
-import { getCommandArgs } from '../utils/command'
-import { labelIssue, cancelLabel } from '../utils/labeling'
+import {getCommandArgs} from '../utils/command'
+import {labelIssue, cancelLabel} from '../utils/labeling'
 
 /**
  * /hold will add the hold label
@@ -17,7 +17,7 @@ import { labelIssue, cancelLabel } from '../utils/labeling'
 export const hold = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })

--- a/src/labels/hold.ts
+++ b/src/labels/hold.ts
@@ -1,10 +1,11 @@
 import * as github from '@actions/github'
+import { Octokit } from '@octokit/rest'
 
-import {Context} from '@actions/github/lib/context'
+import { Context } from '@actions/github/lib/context'
 import * as core from '@actions/core'
 
-import {getCommandArgs} from '../utils/command'
-import {labelIssue, cancelLabel} from '../utils/labeling'
+import { getCommandArgs } from '../utils/command'
+import { labelIssue, cancelLabel } from '../utils/labeling'
 
 /**
  * /hold will add the hold label
@@ -16,11 +17,13 @@ import {labelIssue, cancelLabel} from '../utils/labeling'
 export const hold = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', {required: true})
-  const octokit = new github.GitHub(token)
+  const token = core.getInput('github-token', { required: true })
+  const octokit = new Octokit({
+    auth: token
+  })
 
   const issueNumber: number | undefined = context.payload.issue?.number
-  const commentBody: string = context.payload['comment']['body']
+  const commentBody: string = context.payload.comment?.body
 
   if (issueNumber === undefined) {
     throw new Error(

--- a/src/labels/kind.ts
+++ b/src/labels/kind.ts
@@ -1,11 +1,11 @@
 import * as github from '@actions/github'
-import { Octokit } from '@octokit/rest'
+import {Octokit} from '@octokit/rest'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 import * as core from '@actions/core'
 
-import { getCommandArgs } from '../utils/command'
-import { getArgumentLabels, labelIssue, addPrefix } from '../utils/labeling'
+import {getCommandArgs} from '../utils/command'
+import {getArgumentLabels, labelIssue, addPrefix} from '../utils/labeling'
 
 /**
  * /kind will add a kind/some-kind label
@@ -15,7 +15,7 @@ import { getArgumentLabels, labelIssue, addPrefix } from '../utils/labeling'
 export const kind = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })

--- a/src/labels/kind.ts
+++ b/src/labels/kind.ts
@@ -1,10 +1,11 @@
 import * as github from '@actions/github'
+import { Octokit } from '@octokit/rest'
 
-import {Context} from '@actions/github/lib/context'
+import { Context } from '@actions/github/lib/context'
 import * as core from '@actions/core'
 
-import {getCommandArgs} from '../utils/command'
-import {getArgumentLabels, labelIssue, addPrefix} from '../utils/labeling'
+import { getCommandArgs } from '../utils/command'
+import { getArgumentLabels, labelIssue, addPrefix } from '../utils/labeling'
 
 /**
  * /kind will add a kind/some-kind label
@@ -14,11 +15,13 @@ import {getArgumentLabels, labelIssue, addPrefix} from '../utils/labeling'
 export const kind = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', {required: true})
-  const octokit = new github.GitHub(token)
+  const token = core.getInput('github-token', { required: true })
+  const octokit = new Octokit({
+    auth: token
+  })
 
   const issueNumber: number | undefined = context.payload.issue?.number
-  const commentBody: string = context.payload['comment']['body']
+  const commentBody: string = context.payload.comment?.body
 
   if (issueNumber === undefined) {
     throw new Error(

--- a/src/labels/lgtm.ts
+++ b/src/labels/lgtm.ts
@@ -1,12 +1,13 @@
 import * as github from '@actions/github'
+import { Octokit } from '@octokit/rest'
 
-import {Context} from '@actions/github/lib/context'
+import { Context } from '@actions/github/lib/context'
 import * as core from '@actions/core'
 
-import {getCommandArgs} from '../utils/command'
-import {labelIssue, cancelLabel} from '../utils/labeling'
-import {assertAuthorizedByOwnersOrMembership} from '../utils/auth'
-import {createComment} from '../utils/comments'
+import { getCommandArgs } from '../utils/command'
+import { labelIssue, cancelLabel } from '../utils/labeling'
+import { assertAuthorizedByOwnersOrMembership } from '../utils/auth'
+import { createComment } from '../utils/comments'
 
 /**
  * /lgtm will add the lgtm label.
@@ -18,12 +19,14 @@ import {createComment} from '../utils/comments'
 export const lgtm = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', {required: true})
-  const octokit = new github.GitHub(token)
+  const token = core.getInput('github-token', { required: true })
+  const octokit = new Octokit({
+    auth: token
+  })
 
   const issueNumber: number | undefined = context.payload.issue?.number
-  const commentBody: string = context.payload['comment']['body']
-  const commenterId: string = context.payload['comment']['user']['login']
+  const commentBody: string = context.payload.comment?.body
+  const commenterId: string = context.payload.comment?.user?.login
 
   if (issueNumber === undefined) {
     throw new Error(

--- a/src/labels/lgtm.ts
+++ b/src/labels/lgtm.ts
@@ -1,13 +1,13 @@
 import * as github from '@actions/github'
-import { Octokit } from '@octokit/rest'
+import {Octokit} from '@octokit/rest'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 import * as core from '@actions/core'
 
-import { getCommandArgs } from '../utils/command'
-import { labelIssue, cancelLabel } from '../utils/labeling'
-import { assertAuthorizedByOwnersOrMembership } from '../utils/auth'
-import { createComment } from '../utils/comments'
+import {getCommandArgs} from '../utils/command'
+import {labelIssue, cancelLabel} from '../utils/labeling'
+import {assertAuthorizedByOwnersOrMembership} from '../utils/auth'
+import {createComment} from '../utils/comments'
 
 /**
  * /lgtm will add the lgtm label.
@@ -19,7 +19,7 @@ import { createComment } from '../utils/comments'
 export const lgtm = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })

--- a/src/labels/priority.ts
+++ b/src/labels/priority.ts
@@ -1,11 +1,11 @@
 import * as github from '@actions/github'
-import { Octokit } from '@octokit/rest'
+import {Octokit} from '@octokit/rest'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 import * as core from '@actions/core'
 
-import { getCommandArgs } from '../utils/command'
-import { getArgumentLabels, labelIssue, addPrefix } from '../utils/labeling'
+import {getCommandArgs} from '../utils/command'
+import {getArgumentLabels, labelIssue, addPrefix} from '../utils/labeling'
 
 /**
  * /priority will add a priority/some-priority label
@@ -15,7 +15,7 @@ import { getArgumentLabels, labelIssue, addPrefix } from '../utils/labeling'
 export const priority = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })

--- a/src/labels/priority.ts
+++ b/src/labels/priority.ts
@@ -1,10 +1,11 @@
 import * as github from '@actions/github'
+import { Octokit } from '@octokit/rest'
 
-import {Context} from '@actions/github/lib/context'
+import { Context } from '@actions/github/lib/context'
 import * as core from '@actions/core'
 
-import {getCommandArgs} from '../utils/command'
-import {getArgumentLabels, labelIssue, addPrefix} from '../utils/labeling'
+import { getCommandArgs } from '../utils/command'
+import { getArgumentLabels, labelIssue, addPrefix } from '../utils/labeling'
 
 /**
  * /priority will add a priority/some-priority label
@@ -14,11 +15,13 @@ import {getArgumentLabels, labelIssue, addPrefix} from '../utils/labeling'
 export const priority = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', {required: true})
-  const octokit = new github.GitHub(token)
+  const token = core.getInput('github-token', { required: true })
+  const octokit = new Octokit({
+    auth: token
+  })
 
   const issueNumber: number | undefined = context.payload.issue?.number
-  const commentBody: string = context.payload['comment']['body']
+  const commentBody: string = context.payload.comment?.body
 
   if (issueNumber === undefined) {
     throw new Error(

--- a/src/labels/remove.ts
+++ b/src/labels/remove.ts
@@ -1,11 +1,12 @@
 import * as github from '@actions/github'
+import { Octokit } from '@octokit/rest'
 
-import {Context} from '@actions/github/lib/context'
+import { Context } from '@actions/github/lib/context'
 import * as core from '@actions/core'
 
-import {getCommandArgs} from '../utils/command'
-import {getCurrentLabels, removeLabels} from '../utils/labeling'
-import {checkCollaborator} from '../utils/auth'
+import { getCommandArgs } from '../utils/command'
+import { getCurrentLabels, removeLabels } from '../utils/labeling'
+import { checkCollaborator } from '../utils/auth'
 
 /**
  * /remove will remove a label based on the command argument
@@ -15,12 +16,14 @@ import {checkCollaborator} from '../utils/auth'
 export const remove = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', {required: true})
-  const octokit = new github.GitHub(token)
+  const token = core.getInput('github-token', { required: true })
+  const octokit = new Octokit({
+    auth: token
+  })
 
   const issueNumber: number | undefined = context.payload.issue?.number
-  const commentBody: string = context.payload['comment']['body']
-  const commenterId: string = context.payload['comment']['user']['login']
+  const commentBody: string = context.payload.comment?.body
+  const commenterId: string = context.payload.comment?.user?.login
 
   if (issueNumber === undefined) {
     throw new Error(

--- a/src/labels/remove.ts
+++ b/src/labels/remove.ts
@@ -1,12 +1,12 @@
 import * as github from '@actions/github'
-import { Octokit } from '@octokit/rest'
+import {Octokit} from '@octokit/rest'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 import * as core from '@actions/core'
 
-import { getCommandArgs } from '../utils/command'
-import { getCurrentLabels, removeLabels } from '../utils/labeling'
-import { checkCollaborator } from '../utils/auth'
+import {getCommandArgs} from '../utils/command'
+import {getCurrentLabels, removeLabels} from '../utils/labeling'
+import {checkCollaborator} from '../utils/auth'
 
 /**
  * /remove will remove a label based on the command argument
@@ -16,7 +16,7 @@ import { checkCollaborator } from '../utils/auth'
 export const remove = async (
   context: Context = github.context
 ): Promise<void> => {
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })

--- a/src/pullReq/handlePullReq.ts
+++ b/src/pullReq/handlePullReq.ts
@@ -2,8 +2,8 @@ import * as github from '@actions/github'
 
 import * as core from '@actions/core'
 
-import {Context} from '@actions/github/lib/context'
-import {onPrLgtm} from './onPrLgtm'
+import { Context } from '@actions/github/lib/context'
+import { onPrLgtm } from './onPrLgtm'
 
 /**
  * This method handles any pull-request configuration for configured workflows.
@@ -14,7 +14,7 @@ import {onPrLgtm} from './onPrLgtm'
 export const handlePullReq = async (
   context: Context = github.context
 ): Promise<void> => {
-  const runConfig = core.getInput('jobs', {required: false}).split(' ')
+  const runConfig = core.getInput('jobs', { required: false }).split(' ')
 
   await Promise.all(
     runConfig.map(async command => {

--- a/src/pullReq/handlePullReq.ts
+++ b/src/pullReq/handlePullReq.ts
@@ -2,8 +2,8 @@ import * as github from '@actions/github'
 
 import * as core from '@actions/core'
 
-import { Context } from '@actions/github/lib/context'
-import { onPrLgtm } from './onPrLgtm'
+import {Context} from '@actions/github/lib/context'
+import {onPrLgtm} from './onPrLgtm'
 
 /**
  * This method handles any pull-request configuration for configured workflows.
@@ -14,7 +14,7 @@ import { onPrLgtm } from './onPrLgtm'
 export const handlePullReq = async (
   context: Context = github.context
 ): Promise<void> => {
-  const runConfig = core.getInput('jobs', { required: false }).split(' ')
+  const runConfig = core.getInput('jobs', {required: false}).split(' ')
 
   await Promise.all(
     runConfig.map(async command => {

--- a/src/pullReq/onPrLgtm.ts
+++ b/src/pullReq/onPrLgtm.ts
@@ -1,8 +1,8 @@
-import * as github from '@actions/github'
+import { Octokit } from '@octokit/rest'
 
-import {Context} from '@actions/github/lib/context'
+import { Context } from '@actions/github/lib/context'
 import * as core from '@actions/core'
-import {getCurrentLabels, removeLabels} from '../utils/labeling'
+import { getCurrentLabels, removeLabels } from '../utils/labeling'
 
 /**
  * Removes the 'lgtm' label after a pull request event
@@ -10,8 +10,10 @@ import {getCurrentLabels, removeLabels} from '../utils/labeling'
  * @param context - The github actions event context
  */
 export const onPrLgtm = async (context: Context): Promise<void> => {
-  const token = core.getInput('github-token', {required: true})
-  const octokit = new github.GitHub(token)
+  const token = core.getInput('github-token', { required: true })
+  const octokit = new Octokit({
+    auth: token
+  })
 
   const prNumber: number | undefined = context.payload.pull_request?.number
 

--- a/src/pullReq/onPrLgtm.ts
+++ b/src/pullReq/onPrLgtm.ts
@@ -1,8 +1,8 @@
-import { Octokit } from '@octokit/rest'
+import {Octokit} from '@octokit/rest'
 
-import { Context } from '@actions/github/lib/context'
+import {Context} from '@actions/github/lib/context'
 import * as core from '@actions/core'
-import { getCurrentLabels, removeLabels } from '../utils/labeling'
+import {getCurrentLabels, removeLabels} from '../utils/labeling'
 
 /**
  * Removes the 'lgtm' label after a pull request event
@@ -10,7 +10,7 @@ import { getCurrentLabels, removeLabels } from '../utils/labeling'
  * @param context - The github actions event context
  */
 export const onPrLgtm = async (context: Context): Promise<void> => {
-  const token = core.getInput('github-token', { required: true })
+  const token = core.getInput('github-token', {required: true})
   const octokit = new Octokit({
     auth: token
   })

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
-import { Octokit } from '@octokit/rest'
-import { Context } from '@actions/github/lib/context'
+import {Octokit} from '@octokit/rest'
+import {Context} from '@actions/github/lib/context'
 
 import yaml from 'js-yaml'
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,7 +1,6 @@
-import * as github from '@actions/github'
 import * as core from '@actions/core'
-import {RequestError} from '@octokit/request-error'
-import {Context} from '@actions/github/lib/context'
+import { Octokit } from '@octokit/rest'
+import { Context } from '@actions/github/lib/context'
 
 import yaml from 'js-yaml'
 
@@ -13,7 +12,7 @@ import yaml from 'js-yaml'
  * @param user - the users to check auth on
  */
 export const checkOrgMember = async (
-  octokit: github.GitHub,
+  octokit: Octokit,
   context: Context,
   user: string
 ): Promise<boolean> => {
@@ -23,7 +22,7 @@ export const checkOrgMember = async (
       return false
     }
 
-    await octokit.orgs.checkMembership({
+    await octokit.orgs.checkMembershipForUser({
       org: context.payload.repository.owner.login,
       username: user
     })
@@ -42,7 +41,7 @@ export const checkOrgMember = async (
  * @param user - the users to check auth on
  */
 export const checkCollaborator = async (
-  octokit: github.GitHub,
+  octokit: Octokit,
   context: Context,
   user: string
 ): Promise<boolean> => {
@@ -68,19 +67,21 @@ export const checkCollaborator = async (
  * @param user - the users to check auth on
  */
 export const checkIssueComments = async (
-  octokit: github.GitHub,
+  octokit: Octokit,
   context: Context,
   issueNum: number,
   user: string
 ): Promise<boolean> => {
   try {
+    /* eslint-disable @typescript-eslint/naming-convention */
     const comments = await octokit.issues.listComments({
       ...context.repo,
       issue_number: issueNum
     })
+    /* eslint-enable @typescript-eslint/naming-convention */
 
     for (const e of comments.data) {
-      if (e.user.login === user) {
+      if (e.user?.login === user) {
         return true
       }
     }
@@ -101,7 +102,7 @@ export const checkIssueComments = async (
  * @param args - the users to check auth on
  */
 export const getOrgCollabCommentUsers = async (
-  octokit: github.GitHub,
+  octokit: Octokit,
   context: Context,
   issueNum: number,
   args: string[]
@@ -142,7 +143,7 @@ export const getOrgCollabCommentUsers = async (
  * @param args - the users to check auth on
  */
 export const checkCommenterAuth = async (
-  octokit: github.GitHub,
+  octokit: Octokit,
   context: Context,
   issueNum: number,
   user: string
@@ -183,7 +184,7 @@ export const checkCommenterAuth = async (
  * @param username is the user to authorize
  */
 export const assertAuthorizedByOwnersOrMembership = async (
-  octokit: github.GitHub,
+  octokit: Octokit,
   context: Context,
   role: string,
   username: string
@@ -212,24 +213,22 @@ export const assertAuthorizedByOwnersOrMembership = async (
  * If the file does not exist, returns an empty string.
  */
 async function retrieveOwnersFile(
-  octokit: github.GitHub,
+  octokit: Octokit,
   context: Context
 ): Promise<string> {
   core.debug(`Looking for an OWNERS file at the root of the repository`)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let data: any = undefined
   try {
-    const response = await octokit.repos.getContents({
+    const response = await octokit.repos.getContent({
       ...context.repo,
       path: 'OWNERS'
     })
     data = response.data
   } catch (e) {
-    if (e instanceof RequestError) {
-      if (e.status === 404) {
-        core.debug('No OWNERS file found')
-        return ''
-      }
+    if (typeof e === 'object' && e && 'status' in e && e.status === 404) {
+      core.debug('No OWNERS file found')
+      return ''
     }
 
     throw new Error(
@@ -258,7 +257,8 @@ function isInOwnersFile(
   username: string
 ): boolean {
   core.debug(`checking if ${username} is in the ${role} in the OWNERS file`)
-  const ownersData = yaml.safeLoad(ownersContents)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ownersData: any = yaml.load(ownersContents)
 
   const roleMembers = ownersData[role]
   if ((roleMembers as string[]) !== undefined) {

--- a/src/utils/comments.ts
+++ b/src/utils/comments.ts
@@ -1,5 +1,5 @@
-import * as github from '@actions/github'
-import {Context} from '@actions/github/lib/context'
+import { Octokit } from '@octokit/rest'
+import { Context } from '@actions/github/lib/context'
 
 /**
  * createComment comments on the specified issue or pull request
@@ -10,17 +10,19 @@ import {Context} from '@actions/github/lib/context'
  * @param message - the comment message body
  */
 export const createComment = async (
-  octokit: github.GitHub,
+  octokit: Octokit,
   context: Context,
   issueNum: number,
   message: string
 ): Promise<void> => {
   try {
+    /* eslint-disable @typescript-eslint/naming-convention */
     await octokit.issues.createComment({
       ...context.repo,
       issue_number: issueNum,
       body: message
     })
+    /* eslint-enable @typescript-eslint/naming-convention */
   } catch (e) {
     throw new Error(`could not add comment: ${e}`)
   }

--- a/src/utils/comments.ts
+++ b/src/utils/comments.ts
@@ -1,5 +1,5 @@
-import { Octokit } from '@octokit/rest'
-import { Context } from '@actions/github/lib/context'
+import {Octokit} from '@octokit/rest'
+import {Context} from '@actions/github/lib/context'
 
 /**
  * createComment comments on the specified issue or pull request

--- a/src/utils/labeling.ts
+++ b/src/utils/labeling.ts
@@ -1,5 +1,5 @@
-import * as github from '@actions/github'
-import {Context} from '@actions/github/lib/context'
+import { Octokit } from '@octokit/rest'
+import { Context } from '@actions/github/lib/context'
 import * as core from '@actions/core'
 
 import * as yaml from 'js-yaml'
@@ -16,20 +16,20 @@ import * as yaml from 'js-yaml'
  * @param arg - the label section to return. For example, may be 'area', etc
  */
 export const getArgumentLabels = async (
-  octokit: github.GitHub,
+  octokit: Octokit,
   context: Context,
   arg: string
 ): Promise<string[]> => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let response: any = undefined
   try {
-    response = await octokit.repos.getContents({
+    response = await octokit.repos.getContent({
       ...context.repo,
       path: '.github/labels.yaml'
     })
   } catch (e) {
     try {
-      response = await octokit.repos.getContents({
+      response = await octokit.repos.getContent({
         ...context.repo,
         path: '.github/labels.yml'
       })
@@ -51,7 +51,8 @@ export const getArgumentLabels = async (
     response.data.encoding
   ).toString()
 
-  const content = yaml.safeLoad(decoded)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const content: any = yaml.load(decoded)
 
   if (!content[arg] && !(content[arg] instanceof Array)) {
     throw new Error(`${arg}: yaml malformed, expected '${arg}' top level key`)
@@ -69,17 +70,19 @@ export const getArgumentLabels = async (
  * @param labels - the labels to add to the issue
  */
 export const labelIssue = async (
-  octokit: github.GitHub,
+  octokit: Octokit,
   context: Context,
   issueNum: number,
   labels: string[]
 ): Promise<void> => {
   try {
+    /* eslint-disable @typescript-eslint/naming-convention */
     await octokit.issues.addLabels({
       ...context.repo,
       issue_number: issueNum,
       labels
     })
+    /* eslint-enable @typescript-eslint/naming-convention */
   } catch (e) {
     throw new Error(`could not add labels: ${e}`)
   }
@@ -93,18 +96,23 @@ export const labelIssue = async (
  * @param issueNum - the issue associated with this runtime
  */
 export const getCurrentLabels = async (
-  octokit: github.GitHub,
+  octokit: Octokit,
   context: Context,
   issueNum: number
 ): Promise<string[]> => {
   try {
+    /* eslint-disable @typescript-eslint/naming-convention */
     const issue = await octokit.issues.get({
       ...context.repo,
       issue_number: issueNum
     })
+    /* eslint-enable @typescript-eslint/naming-convention */
 
-    return issue.data.labels.map(e => {
-      return e.name
+    return issue.data.labels.map((e): string => {
+      if (typeof e == 'object') {
+        return e.name || ""
+      }
+      return e
     })
   } catch (e) {
     throw new Error(`could not get issue: ${e}`)
@@ -120,18 +128,20 @@ export const getCurrentLabels = async (
  * @param labels - the labels to remove from the issue
  */
 export const removeLabels = async (
-  octokit: github.GitHub,
+  octokit: Octokit,
   context: Context,
   issueNum: number,
   labels: string[]
 ): Promise<void> => {
   for (const label of labels) {
     try {
+      /* eslint-disable @typescript-eslint/naming-convention */
       await octokit.issues.removeLabel({
         ...context.repo,
         issue_number: issueNum,
         name: label
       })
+      /* eslint-enable @typescript-eslint/naming-convention */
     } catch (e) {
       core.debug(`could not remove labels: ${e}`)
     }
@@ -163,7 +173,7 @@ export const addPrefix = (prefix: string, args: string[]): string[] => {
  * @param labels - the label to remove from the issue
  */
 export const cancelLabel = async (
-  octokit: github.GitHub,
+  octokit: Octokit,
   context: Context,
   issueNum: number,
   label: string

--- a/src/utils/labeling.ts
+++ b/src/utils/labeling.ts
@@ -1,5 +1,5 @@
-import { Octokit } from '@octokit/rest'
-import { Context } from '@actions/github/lib/context'
+import {Octokit} from '@octokit/rest'
+import {Context} from '@actions/github/lib/context'
 import * as core from '@actions/core'
 
 import * as yaml from 'js-yaml'
@@ -110,7 +110,7 @@ export const getCurrentLabels = async (
 
     return issue.data.labels.map((e): string => {
       if (typeof e == 'object') {
-        return e.name || ""
+        return e.name || ''
       }
       return e
     })


### PR DESCRIPTION
Refactor: Bring everything up to speed with new deps and node 20

* Based on works of John McBride (@jpmcb)
* Update dependencies:
  + Bump:
    + @typescript-eslint/eslint-plugin: ^6.7.0
    + @typescript-eslint/parser: ^6.7.0
    + eslint: ^8.49.0
    + typescript: ^5.2.2
  + Add:
    + eslint-import-resolver-typescript: ^3.6.0
      Required for eslint to work with typescript import resolver
    + msw: ^1.3.1
      Introduced to replace nock
  + Replace deprecated:
    + Replace @zeit/ncc with @vercel/ncc, upstream suggestion
      Build error: digital envelope routines::unsupported
  + Drop:
    + nock due to the issue [1] related to the fetch experimental
      feature of nodejs
* Refactor code:
  + TypeScript compile errors
  + ESLint errors and warnings
  + Tests reimplement GitHub API responses mockup using msw/node instead
    of nock
* Declare the action runs using node20

---
[1] https://github.com/nock/nock/issues/2397